### PR TITLE
Update GitHub links to reflect repo transfer

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -30,4 +30,4 @@ You are advised to review this Privacy Policy periodically for any changes. Chan
 
 If you have any questions about this Privacy Policy, You can contact us:
 
-- By visiting this page: [https://github.com/jwr1/interstellar/issues/new/choose](https://github.com/jwr1/interstellar/issues/new/choose)
+- By visiting this page: [https://github.com/interstellar-app/interstellar/issues/new/choose](https://github.com/interstellar-app/interstellar/issues/new/choose)

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Interstellar supports Android, Linux, and Windows, with more to come.
 
 Available for Arch Linux via the AUR: [interstellar-bin](https://aur.archlinux.org/packages/interstellar-bin).
 
-See the [latest release](https://github.com/jwr1/interstellar/releases/latest) for more downloads (.APK, .AppImage, .exe, etc.).
+See the [latest release](https://github.com/interstellar-app/interstellar/releases/latest) for more downloads (.APK, .AppImage, .exe, etc.).
 
 ## Discussion
 
 You can ask questions, report bugs, make suggestions, etc., to any of the following:
 
-- [GitHub](https://github.com/jwr1/interstellar/issues)
+- [GitHub](https://github.com/interstellar-app/interstellar/issues)
 - [Mbin](https://kbin.earth/m/interstellar)
 - [Matrix](https://matrix.to/#/#interstellar-space:matrix.org)
 

--- a/lib/src/api/client.dart
+++ b/lib/src/api/client.dart
@@ -134,7 +134,7 @@ class ServerClient {
 
 extension BodyJson on http.Response {
   JsonMap get bodyJson {
-    // Force utf8 decoding due to Lemmy not providing correct content type headers (https://github.com/jwr1/interstellar/pull/50)
+    // Force utf8 decoding due to Lemmy not providing correct content type headers (https://github.com/interstellar-app/interstellar/pull/50)
     return jsonDecode(utf8.decode(bodyBytes)) as JsonMap;
   }
 }

--- a/lib/src/screens/settings/about_screen.dart
+++ b/lib/src/screens/settings/about_screen.dart
@@ -8,10 +8,11 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
 
 const _donateLink = 'https://github.com/sponsors/jwr1';
-const _contributeLink = 'https://github.com/jwr1/interstellar';
+const _contributeLink = 'https://github.com/interstellar-app/interstellar';
 const _translateLink =
     'https://hosted.weblate.org/projects/interstellar/interstellar/';
-const _reportIssueLink = 'https://github.com/jwr1/interstellar/issues';
+const _reportIssueLink =
+    'https://github.com/interstellar-app/interstellar/issues';
 const _matrixSpaceLink = 'https://matrix.to/#/#interstellar-space:matrix.org';
 const _mbinMagazineName = 'interstellar@kbin.earth';
 const _mbinMagazineLink = 'https://kbin.earth/m/interstellar';

--- a/scripts/build-windows-setup.iss
+++ b/scripts/build-windows-setup.iss
@@ -4,7 +4,7 @@
 #define AppName "Interstellar"
 #define AppVersion GetEnv('INTERSTELLAR_VERSION')
 #define AppPublisher "jwr1"
-#define AppURL "https://github.com/jwr1/interstellar"
+#define AppURL "https://github.com/interstellar-app/interstellar"
 #define AppExeName "interstellar.exe"
 
 #define AppSourceDir GetEnv('GITHUB_WORKSPACE')


### PR DESCRIPTION
I've created a GH org for Interstellar and have transferred the repository to the new org. This means we need to change any references of `jwr1/interstellar` to `interstellar-app/interstellar`. Although this makes the URL twice as long, it will allow us to group and manage future repositories in the same organization.

@olorin99, as I'm sure you've already noticed, I have invited you to be an owner of the new org.

I'll also take this moment to mention @IzzySoft, as I'm sure there are links that need to be updated on your end?