### PR TITLE
Mark as read fixes

### DIFF
--- a/lib/src/screens/feed/feed_screen.dart
+++ b/lib/src/screens/feed/feed_screen.dart
@@ -78,7 +78,8 @@ class _FeedScreenState extends State<FeedScreen>
     _view = context.read<AppController>().serverSoftware == ServerSoftware.mbin
         ? context.read<AppController>().profile.feedDefaultView
         : FeedView.threads;
-    _hideReadPosts = context.read<AppController>().profile.feedDefaultHideReadPosts;
+    _hideReadPosts =
+        context.read<AppController>().profile.feedDefaultHideReadPosts;
   }
 
   @override
@@ -196,7 +197,7 @@ class _FeedScreenState extends State<FeedScreen>
               context.watch<AppController>().profile.feedActionHideReadPosts,
               () => setState(() {
                 _hideReadPosts = !_hideReadPosts;
-              })
+              }),
             )
           : feedActionHideReadPosts(context).withProps(
               context.watch<AppController>().profile.feedActionHideReadPosts,
@@ -398,7 +399,8 @@ class _FeedScreenState extends State<FeedScreen>
                         hideReadPosts: _hideReadPosts,
                       ),
                       // TODO: Remove once federation filter is added to mbin api.
-                      if (context.read<AppController>().serverSoftware != ServerSoftware.mbin)
+                      if (context.read<AppController>().serverSoftware !=
+                          ServerSoftware.mbin)
                         FeedScreenBody(
                           key: _getFeedKey(4),
                           source: FeedSource.local,
@@ -583,42 +585,42 @@ SelectionMenu<FeedSort> feedSortSelect(BuildContext context) {
           value: FeedSort.commented,
           title: l(context).sort_commented,
           icon: Symbols.chat_rounded,
-            subItems: isLemmy || isPiefed
-                ? null
-                : [
-                    SelectionMenuItem(
-                        value: FeedSort.commentedThreeHour,
-                        title: l(context).sort_commented_3h,
-                    ),
-                    SelectionMenuItem(
-                        value: FeedSort.commentedSixHour,
-                        title: l(context).sort_commented_6h,
-                    ),
-                    SelectionMenuItem(
-                        value: FeedSort.commentedTwelveHour,
-                        title: l(context).sort_commented_12h,
-                    ),
-                    SelectionMenuItem(
-                        value: FeedSort.commentedDay,
-                        title: l(context).sort_commented_1d,
-                    ),
-                    SelectionMenuItem(
-                        value: FeedSort.commentedWeek,
-                        title: l(context).sort_commented_1w,
-                    ),
-                    SelectionMenuItem(
-                        value: FeedSort.commentedMonth,
-                        title: l(context).sort_commented_1m,
-                    ),
-                    SelectionMenuItem(
-                        value: FeedSort.commentedYear,
-                        title: l(context).sort_commented_1y,
-                    ),
-                    SelectionMenuItem(
-                        value: FeedSort.commented,
-                        title: l(context).sort_commented_all,
-                    ),
-            ]
+          subItems: isLemmy || isPiefed
+              ? null
+              : [
+                  SelectionMenuItem(
+                    value: FeedSort.commentedThreeHour,
+                    title: l(context).sort_commented_3h,
+                  ),
+                  SelectionMenuItem(
+                    value: FeedSort.commentedSixHour,
+                    title: l(context).sort_commented_6h,
+                  ),
+                  SelectionMenuItem(
+                    value: FeedSort.commentedTwelveHour,
+                    title: l(context).sort_commented_12h,
+                  ),
+                  SelectionMenuItem(
+                    value: FeedSort.commentedDay,
+                    title: l(context).sort_commented_1d,
+                  ),
+                  SelectionMenuItem(
+                    value: FeedSort.commentedWeek,
+                    title: l(context).sort_commented_1w,
+                  ),
+                  SelectionMenuItem(
+                    value: FeedSort.commentedMonth,
+                    title: l(context).sort_commented_1m,
+                  ),
+                  SelectionMenuItem(
+                    value: FeedSort.commentedYear,
+                    title: l(context).sort_commented_1y,
+                  ),
+                  SelectionMenuItem(
+                    value: FeedSort.commented,
+                    title: l(context).sort_commented_all,
+                  ),
+                ],
         ),
         SelectionMenuItem(
           value: FeedSort.oldest,
@@ -914,13 +916,11 @@ class _FeedScreenBodyState extends State<FeedScreenBody>
 
       final ac = context.read<AppController>();
 
-      final finalItems = ac.serverSoftware
-          == ServerSoftware.lemmy && ac.isLoggedIn
-          ? items
-          : await Future.wait(items.map((item) async =>
-            (await ac.isRead(item.id))
-                ? item.copyWith(read: true)
-                : item));
+      final finalItems =
+          ac.serverSoftware == ServerSoftware.lemmy && ac.isLoggedIn
+              ? items
+              : await Future.wait(items.map((item) async =>
+                  (await ac.isRead(item)) ? item.copyWith(read: true) : item));
 
       _pagingController.appendPage(finalItems, nextPageKey);
     } catch (error) {
@@ -1030,7 +1030,8 @@ class _FeedScreenBodyState extends State<FeedScreenBody>
                                 );
                           }),
                           onTap: onPostTap,
-                          filterListWarnings: _filterListWarnings[(item.type, item.id)],
+                          filterListWarnings:
+                              _filterListWarnings[(item.type, item.id)],
                           userCanModerate: widget.userCanModerate,
                           isTopLevel: true,
                           isCompact: true,
@@ -1064,20 +1065,17 @@ class _FeedScreenBodyState extends State<FeedScreenBody>
                       onTap: onPostTap,
                       isPreview: true,
                       onReply: whenLoggedIn(context, (body) async {
-                        await context
-                            .read<AppController>()
-                            .api
-                            .comments
-                            .create(
+                        await context.read<AppController>().api.comments.create(
                               item.type,
                               item.id,
                               body,
                             );
                       }),
-                      filterListWarnings: _filterListWarnings[(item.type, item.id)],
+                      filterListWarnings:
+                          _filterListWarnings[(item.type, item.id)],
                       userCanModerate: widget.userCanModerate,
                       isTopLevel: true,
-                    )
+                    ),
                   );
                 }
               },

--- a/lib/src/screens/feed/post_item.dart
+++ b/lib/src/screens/feed/post_item.dart
@@ -41,23 +41,20 @@ class PostItem extends StatefulWidget {
 
   @override
   State<PostItem> createState() => _PostItemState();
-
 }
 
 class _PostItemState extends State<PostItem> {
-
   Translation? _translation;
 
   @override
   void initState() {
     super.initState();
     if (context.read<AppController>().profile.autoTranslate &&
-        widget.item.lang != context.read<AppController>().profile.defaultPostLanguage &&
-        widget.item.body != null && widget.item.lang != null) {
-      getTranslation(context
-          .read<AppController>()
-          .profile
-          .defaultPostLanguage);
+        widget.item.lang !=
+            context.read<AppController>().profile.defaultPostLanguage &&
+        widget.item.body != null &&
+        widget.item.lang != null) {
+      getTranslation(context.read<AppController>().profile.defaultPostLanguage);
     }
   }
 
@@ -80,7 +77,8 @@ class _PostItemState extends State<PostItem> {
   Widget build(BuildContext context) {
     final ac = context.watch<AppController>();
 
-    final canModerate = widget.userCanModerate || (widget.item.canAuthUserModerate ?? false);
+    final canModerate =
+        widget.userCanModerate || (widget.item.canAuthUserModerate ?? false);
 
     final contentItem = ContentItem(
       originInstance: getNameHost(context, widget.item.user.name),
@@ -95,7 +93,8 @@ class _PostItemState extends State<PostItem> {
       },
       createdAt: widget.item.createdAt,
       editedAt: widget.item.editedAt,
-      isPreview: widget.item.type == PostType.microblog ? false : widget.isPreview,
+      isPreview:
+          widget.item.type == PostType.microblog ? false : widget.isPreview,
       fullImageSize: widget.isPreview
           ? switch (widget.item.type) {
               PostType.thread => ac.profile.fullImageSizeThreads,
@@ -120,35 +119,45 @@ class _PostItemState extends State<PostItem> {
       boosts: widget.item.boosts,
       isBoosted: widget.item.myBoost == true,
       onBoost: whenLoggedIn(context, () async {
-        widget.onUpdate(await ac.markAsRead(await switch (widget.item.type) {
-          PostType.thread => ac.api.threads.boost(widget.item.id),
-          PostType.microblog => ac.api.microblogs.putVote(widget.item.id, 1),
-        }, true));
+        widget.onUpdate(await ac.markAsRead(
+          await switch (widget.item.type) {
+            PostType.thread => ac.api.threads.boost(widget.item.id),
+            PostType.microblog => ac.api.microblogs.putVote(widget.item.id, 1),
+          },
+          true,
+        ));
       }),
       upVotes: widget.item.upvotes,
       isUpVoted: widget.item.myVote == 1,
       onUpVote: whenLoggedIn(context, () async {
-        widget.onUpdate(await ac.markAsRead(await switch (widget.item.type) {
-          PostType.thread =>
-            ac.api.threads.vote(widget.item.id, 1, widget.item.myVote == 1 ? 0 : 1),
-          PostType.microblog => ac.api.microblogs.putFavorite(widget.item.id),
-        }, true));
+        widget.onUpdate(await ac.markAsRead(
+          await switch (widget.item.type) {
+            PostType.thread => ac.api.threads
+                .vote(widget.item.id, 1, widget.item.myVote == 1 ? 0 : 1),
+            PostType.microblog => ac.api.microblogs.putFavorite(widget.item.id),
+          },
+          true,
+        ));
       }),
       downVotes: widget.item.downvotes,
       isDownVoted: widget.item.myVote == -1,
       onDownVote: whenLoggedIn(context, () async {
-        widget.onUpdate(await ac.markAsRead(await switch (widget.item.type) {
-          PostType.thread =>
-            ac.api.threads.vote(widget.item.id, -1, widget.item.myVote == -1 ? 0 : -1),
-          PostType.microblog => ac.api.microblogs.putVote(widget.item.id, -1),
-        }, true));
+        widget.onUpdate(await ac.markAsRead(
+          await switch (widget.item.type) {
+            PostType.thread => ac.api.threads
+                .vote(widget.item.id, -1, widget.item.myVote == -1 ? 0 : -1),
+            PostType.microblog => ac.api.microblogs.putVote(widget.item.id, -1),
+          },
+          true,
+        ));
       }),
       contentTypeName: l(context).post,
       onReply: widget.onReply,
       onReport: whenLoggedIn(context, (reason) async {
         await switch (widget.item.type) {
           PostType.thread => ac.api.threads.report(widget.item.id, reason),
-          PostType.microblog => ac.api.microblogs.report(widget.item.id, reason),
+          PostType.microblog =>
+            ac.api.microblogs.report(widget.item.id, reason),
         };
       }),
       onEdit: widget.onEdit,
@@ -159,20 +168,20 @@ class _PostItemState extends State<PostItem> {
       onModeratePin: !canModerate
           ? null
           : () async {
-              widget.onUpdate(
-                  await ac.api.moderation.postPin(widget.item.type, widget.item.id));
+              widget.onUpdate(await ac.api.moderation
+                  .postPin(widget.item.type, widget.item.id));
             },
       onModerateMarkNSFW: !canModerate
           ? null
           : () async {
-              widget.onUpdate(await ac.api.moderation
-                  .postMarkNSFW(widget.item.type, widget.item.id, !widget.item.isNSFW));
+              widget.onUpdate(await ac.api.moderation.postMarkNSFW(
+                  widget.item.type, widget.item.id, !widget.item.isNSFW));
             },
       onModerateDelete: !canModerate
           ? null
           : () async {
-              widget.onUpdate(
-                  await ac.api.moderation.postDelete(widget.item.type, widget.item.id, true));
+              widget.onUpdate(await ac.api.moderation
+                  .postDelete(widget.item.type, widget.item.id, true));
             },
       onModerateBan: !canModerate
           ? null
@@ -246,7 +255,9 @@ class _PostItemState extends State<PostItem> {
         matchesSoftware: ServerSoftware.mbin,
       ),
       notificationControlStatus: widget.item.notificationControlStatus,
-      onNotificationControlStatusChange: widget.item.notificationControlStatus == null
+      onNotificationControlStatusChange: widget
+                  .item.notificationControlStatus ==
+              null
           ? null
           : (newStatus) async {
               await ac.api.notifications.updateControl(
@@ -259,7 +270,8 @@ class _PostItemState extends State<PostItem> {
                 status: newStatus,
               );
 
-              widget.onUpdate(widget.item.copyWith(notificationControlStatus: newStatus));
+              widget.onUpdate(
+                  widget.item.copyWith(notificationControlStatus: newStatus));
             },
       isCompact: widget.isCompact,
     );
@@ -267,22 +279,22 @@ class _PostItemState extends State<PostItem> {
     return !widget.isTopLevel
         ? contentItem
         : InkWell(
-          onTap: widget.onTap,
-          onLongPress: () => showContentMenu(
+            onTap: widget.onTap,
+            onLongPress: () => showContentMenu(
               context,
               contentItem,
               onTranslate: (String lang) async {
                 await getTranslation(lang);
-              }
-          ),
-          onSecondaryTap: () => showContentMenu(
+              },
+            ),
+            onSecondaryTap: () => showContentMenu(
               context,
               contentItem,
               onTranslate: (String lang) async {
                 await getTranslation(lang);
-              }
-          ),
-          child: contentItem,
-        );
+              },
+            ),
+            child: contentItem,
+          );
   }
 }

--- a/lib/src/screens/feed/post_page.dart
+++ b/lib/src/screens/feed/post_page.dart
@@ -52,7 +52,6 @@ class _PostPageState extends State<PostPage> {
   void _initData() async {
     if (widget.initData != null) {
       _data = widget.initData!;
-      _markAsRead();
     } else if (widget.postType != null && widget.postId != null) {
       final newPost = await switch (widget.postType!) {
         PostType.thread =>
@@ -62,13 +61,14 @@ class _PostPageState extends State<PostPage> {
       };
       setState(() {
         _data = newPost;
-        _markAsRead();
       });
     } else {
       throw Exception('Post data was uninitialized');
     }
 
     _pagingController.addPageRequestListener(_fetchPage);
+
+    _onUpdate(await context.read<AppController>().markAsRead(_data!, true));
   }
 
   void _onUpdate(PostModel newValue) {
@@ -76,14 +76,6 @@ class _PostPageState extends State<PostPage> {
       _data = newValue;
     });
     widget.onUpdate?.call(newValue);
-  }
-
-  void _markAsRead() async {
-    // delay marking as read to prevent error caused by triggering parent build during child build
-    await Future.delayed(const Duration(seconds: 1));
-    if (!mounted) return;
-    widget.onUpdate?.call(
-        await context.read<AppController>().markAsRead(_data!, true));
   }
 
   Future<void> _fetchPage(String pageKey) async {

--- a/lib/src/widgets/content_item/content_item.dart
+++ b/lib/src/widgets/content_item/content_item.dart
@@ -180,13 +180,7 @@ class _ContentItemState extends State<ContentItem> {
 
   @override
   Widget build(BuildContext context) {
-    return DefaultTextStyle(
-      style: widget.read
-          ? Theme.of(context).textTheme.bodyMedium!.copyWith(
-            color: Theme.of(context).textTheme.bodyMedium?.color?.darken(10))
-          : Theme.of(context).textTheme.bodyMedium!,
-      child: widget.isCompact ? compact() : full()
-    );
+    return widget.isCompact ? compact() : full();
   }
 
   Widget contentBody(BuildContext context) {
@@ -234,8 +228,8 @@ class _ContentItemState extends State<ContentItem> {
                     ],
                   ),
                   Divider(),
-                  Markdown(
-                      widget.translation!.translations.text, widget.originInstance),
+                  Markdown(widget.translation!.translations.text,
+                      widget.originInstance),
                 ],
               )
         // No translation is available
@@ -368,14 +362,14 @@ class _ContentItemState extends State<ContentItem> {
                     ));
 
       final titleStyle = hasWideSize
-          ? Theme.of(context).textTheme.titleLarge!.copyWith(
-            color: widget.read
-                ? Theme.of(context).textTheme.titleLarge!.color!.darken(10)
-                : null)
-          : Theme.of(context).textTheme.titleMedium!.copyWith(
-            color: widget.read
-                ? Theme.of(context).textTheme.titleMedium!.color!.darken(10)
-                : null);
+          ? Theme.of(context)
+              .textTheme
+              .titleLarge!
+              .copyWith(fontWeight: widget.read ? FontWeight.w100 : null)
+          : Theme.of(context)
+              .textTheme
+              .titleMedium!
+              .copyWith(fontWeight: widget.read ? FontWeight.w100 : null);
       final titleOverflow =
           widget.isPreview && context.watch<AppController>().profile.compactMode
               ? TextOverflow.ellipsis
@@ -385,12 +379,12 @@ class _ContentItemState extends State<ContentItem> {
         icon: const Icon(Symbols.more_vert_rounded),
         onPressed: () {
           showContentMenu(
-              context,
-              widget,
-              onEdit: () => setState(() {
-                _editTextController = TextEditingController(text: widget.body);
-              }),
-              onTranslate: widget.onTranslate,
+            context,
+            widget,
+            onEdit: () => setState(() {
+              _editTextController = TextEditingController(text: widget.body);
+            }),
+            onTranslate: widget.onTranslate,
           );
         },
       );
@@ -652,12 +646,7 @@ class _ContentItemState extends State<ContentItem> {
                                     padding: const EdgeInsets.only(right: 8),
                                     child: Row(
                                       children: [
-                                        Icon(
-                                          Symbols.comment_rounded,
-                                          color: widget.read
-                                              ? Theme.of(context).textTheme.bodyMedium!.color!.darken(10)
-                                              : null,
-                                        ),
+                                        Icon(Symbols.comment_rounded),
                                         const SizedBox(width: 4),
                                         Text(intFormat(widget.numComments!))
                                       ],
@@ -701,7 +690,8 @@ class _ContentItemState extends State<ContentItem> {
                           ),
                           if (!widget.isPreview &&
                               widget.notificationControlStatus != null &&
-                              widget.onNotificationControlStatusChange != null &&
+                              widget.onNotificationControlStatusChange !=
+                                  null &&
                               context.read<AppController>().serverSoftware !=
                                   ServerSoftware.piefed)
                             Padding(
@@ -825,72 +815,72 @@ class _ContentItemState extends State<ContentItem> {
     final imageWidget = widget.image == null
         ? null
         : SizedBox(
-      height: 96,
-      width: 96,
-      child: AdvancedImage(
-        widget.image!,
-        fit: BoxFit.cover,
-        openTitle: widget.title,
-        enableBlur: widget.isNSFW &&
-            context
-                .watch<AppController>()
-                .profile
-                .coverMediaMarkedSensitive,
-      ),
-    );
+            height: 96,
+            width: 96,
+            child: AdvancedImage(
+              widget.image!,
+              fit: BoxFit.cover,
+              openTitle: widget.title,
+              enableBlur: widget.isNSFW &&
+                  context
+                      .watch<AppController>()
+                      .profile
+                      .coverMediaMarkedSensitive,
+            ),
+          );
 
     final Widget? userWidget = widget.user != null
         ? Flexible(
-      child: Padding(
-        padding: const EdgeInsets.only(right: 10),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Flexible(
-              child: DisplayName(
-                widget.user!,
-                onTap: widget.userIdOnClick != null
-                    ? () => Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (context) => UserScreen(
-                      widget.userIdOnClick!,
+            child: Padding(
+              padding: const EdgeInsets.only(right: 10),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Flexible(
+                    child: DisplayName(
+                      widget.user!,
+                      onTap: widget.userIdOnClick != null
+                          ? () => Navigator.of(context).push(
+                                MaterialPageRoute(
+                                  builder: (context) => UserScreen(
+                                    widget.userIdOnClick!,
+                                  ),
+                                ),
+                              )
+                          : null,
                     ),
                   ),
-                )
-                    : null,
-              ),
-            ),
-            UserStatusIcons(
-              cakeDay: widget.userCakeDay,
-              isBot: widget.userIsBot,
-            ),
-          ],
-        ),
-      ),
-    )
-        : null;
-    final Widget? magazineWidget = widget.magazine != null
-        ? Flexible(
-      child: Padding(
-        padding: const EdgeInsets.only(right: 10),
-        child: DisplayName(
-          widget.magazine!,
-          onTap: widget.magazineIdOnClick != null
-              ? () => Navigator.of(context).push(
-            MaterialPageRoute(
-              builder: (context) => MagazineScreen(
-                widget.magazineIdOnClick!,
+                  UserStatusIcons(
+                    cakeDay: widget.userCakeDay,
+                    isBot: widget.userIsBot,
+                  ),
+                ],
               ),
             ),
           )
-              : null,
-        ),
-      ),
-    )
+        : null;
+    final Widget? magazineWidget = widget.magazine != null
+        ? Flexible(
+            child: Padding(
+              padding: const EdgeInsets.only(right: 10),
+              child: DisplayName(
+                widget.magazine!,
+                onTap: widget.magazineIdOnClick != null
+                    ? () => Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (context) => MagazineScreen(
+                              widget.magazineIdOnClick!,
+                            ),
+                          ),
+                        )
+                    : null,
+              ),
+            ),
+          )
         : null;
 
     final replyDraftController =
-    context.watch<DraftsController>().auto(widget.replyDraftResourceId);
+        context.watch<DraftsController>().auto(widget.replyDraftResourceId);
 
     return Wrapper(
       shouldWrap: context.watch<AppController>().profile.enableSwipeActions,
@@ -909,8 +899,8 @@ class _ContentItemState extends State<ContentItem> {
         },
         onReply: widget.onReply != null
             ? () => setState(() {
-          _replyTextController = TextEditingController();
-        })
+                  _replyTextController = TextEditingController();
+                })
             : () {},
         onModeratePin: widget.onModeratePin,
         onModerateMarkNSFW: widget.onModerateMarkNSFW,
@@ -929,7 +919,8 @@ class _ContentItemState extends State<ContentItem> {
                 children: [
                   Text(
                     widget.title ?? '',
-                    style: Theme.of(context).textTheme.titleMedium,
+                    style: Theme.of(context).textTheme.titleMedium!.copyWith(
+                        fontWeight: widget.read ? FontWeight.w100 : null),
                     softWrap: false,
                     overflow: TextOverflow.ellipsis,
                   ),
@@ -955,8 +946,8 @@ class _ContentItemState extends State<ContentItem> {
                           child: Tooltip(
                             message: l(context).pinnedInMagazine,
                             triggerMode: TooltipTriggerMode.tap,
-                            child: const Icon(Symbols.push_pin_rounded,
-                                size: 20),
+                            child:
+                                const Icon(Symbols.push_pin_rounded, size: 20),
                           ),
                         ),
                       if (widget.isNSFW)
@@ -998,15 +989,15 @@ class _ContentItemState extends State<ContentItem> {
                           padding: const EdgeInsets.only(right: 10),
                           child: Tooltip(
                             message: l(context).createdAt(
-                                dateTimeFormat(widget.createdAt!)) +
+                                    dateTimeFormat(widget.createdAt!)) +
                                 (widget.editedAt == null
                                     ? ''
                                     : '\n${l(context).editedAt(dateTimeFormat(widget.editedAt!))}'),
                             triggerMode: TooltipTriggerMode.tap,
                             child: Text(
                               dateDiffFormat(widget.createdAt!),
-                              style: const TextStyle(
-                                  fontWeight: FontWeight.w300),
+                              style:
+                                  const TextStyle(fontWeight: FontWeight.w300),
                             ),
                           ),
                         ),
@@ -1042,9 +1033,9 @@ class _ContentItemState extends State<ContentItem> {
                             children: [
                               OutlinedButton(
                                   onPressed: () => setState(() {
-                                    _replyTextController!.dispose();
-                                    _replyTextController = null;
-                                  }),
+                                        _replyTextController!.dispose();
+                                        _replyTextController = null;
+                                      }),
                                   child: Text(l(context).cancel)),
                               const SizedBox(width: 8),
                               LoadingFilledButton(
@@ -1073,7 +1064,7 @@ class _ContentItemState extends State<ContentItem> {
           ),
           if (imageWidget != null) imageWidget,
         ],
-      )
+      ),
     );
   }
 }

--- a/lib/src/widgets/content_item/content_menu.dart
+++ b/lib/src/widgets/content_item/content_menu.dart
@@ -16,30 +16,31 @@ import 'package:interstellar/src/widgets/content_item/content_item.dart';
 import 'package:interstellar/src/widgets/loading_list_tile.dart';
 
 void showContentMenu(
-    BuildContext context,
-    ContentItem widget, {
-      Function()? onEdit,
-      Function(String lang)? onTranslate,
+  BuildContext context,
+  ContentItem widget, {
+  Function()? onEdit,
+  Function(String lang)? onTranslate,
 }) {
   final ac = context.read<AppController>();
 
-  showModalBottomSheet(context: context, builder: (BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Flexible(
-          child: Padding(
-            padding: const EdgeInsets.all(20),
-            child: ListView(
-              shrinkWrap: true,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.only(top: 8, bottom: 20),
-                  child: LayoutBuilder(builder: (context, constraints) {
-                    final votingWidgets = [
-                      if (widget.boosts != null)
-                        Row(
-                          children: [
+  showModalBottomSheet(
+    context: context,
+    builder: (BuildContext context) {
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Flexible(
+            child: Padding(
+              padding: const EdgeInsets.all(20),
+              child: ListView(
+                shrinkWrap: true,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8, bottom: 20),
+                    child: LayoutBuilder(builder: (context, constraints) {
+                      final votingWidgets = [
+                        if (widget.boosts != null)
+                          Row(children: [
                             IconButton(
                               onPressed: () {
                                 widget.onBoost!();
@@ -51,11 +52,9 @@ void showContentMenu(
                                   : null,
                             ),
                             Text(intFormat(widget.boosts!)),
-                          ]
-                        ),
-                      if (widget.upVotes != null)
-                        Row(
-                          children: [
+                          ]),
+                        if (widget.upVotes != null)
+                          Row(children: [
                             IconButton(
                               onPressed: () {
                                 widget.onUpVote!();
@@ -67,11 +66,9 @@ void showContentMenu(
                                   : null,
                             ),
                             Text(intFormat(widget.upVotes!)),
-                          ]
-                        ),
-                      if (widget.downVotes != null)
-                        Row(
-                          children: [
+                          ]),
+                        if (widget.downVotes != null)
+                          Row(children: [
                             IconButton(
                               onPressed: () {
                                 widget.onDownVote!();
@@ -83,354 +80,373 @@ void showContentMenu(
                                   : null,
                             ),
                             Text(intFormat(widget.downVotes!)),
-                          ]
-                        )
-                    ];
+                          ])
+                      ];
 
-                    return constraints.maxWidth < 400
-                      ? Column(
-                        children: [
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                            children: votingWidgets,
-                          ),
-                          if (widget.notificationControlStatus != null &&
-                              widget.onNotificationControlStatusChange != null &&
-                              ((ac.serverSoftware == ServerSoftware.mbin &&
-                                  widget.contentTypeName != l(context).comment) ||
-                                  ac.serverSoftware == ServerSoftware.piefed))
-                            Row(
-                              mainAxisAlignment: MainAxisAlignment.center,
+                      return constraints.maxWidth < 400
+                          ? Column(
                               children: [
-                                NotificationControlSegment(
-                                  widget.notificationControlStatus!,
-                                  widget.onNotificationControlStatusChange!,
+                                Row(
+                                  mainAxisAlignment:
+                                      MainAxisAlignment.spaceEvenly,
+                                  children: votingWidgets,
                                 ),
-                            ],
-                          )
-                        ],
-                      )
-                      : Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                        children: [
-                          ...votingWidgets,
-                          if (widget.notificationControlStatus != null &&
-                              widget.onNotificationControlStatusChange != null &&
-                              ((ac.serverSoftware == ServerSoftware.mbin &&
-                                  widget.contentTypeName != l(context).comment) ||
-                                  ac.serverSoftware == ServerSoftware.piefed))
-                            Padding(
-                              padding: const EdgeInsets.fromLTRB(10, 0, 0, 0),
-                              child: NotificationControlSegment(
-                                widget.notificationControlStatus!,
-                                (status) async {
-                                  widget.onNotificationControlStatusChange!(status);
-                                  Navigator.pop(context);
-                                },
-                              ),
+                                if (widget.notificationControlStatus != null &&
+                                    widget.onNotificationControlStatusChange !=
+                                        null &&
+                                    ((ac.serverSoftware ==
+                                                ServerSoftware.mbin &&
+                                            widget.contentTypeName !=
+                                                l(context).comment) ||
+                                        ac.serverSoftware ==
+                                            ServerSoftware.piefed))
+                                  Row(
+                                    mainAxisAlignment: MainAxisAlignment.center,
+                                    children: [
+                                      NotificationControlSegment(
+                                        widget.notificationControlStatus!,
+                                        widget
+                                            .onNotificationControlStatusChange!,
+                                      ),
+                                    ],
+                                  )
+                              ],
                             )
-                        ],
-                      );
-                  }),
-                ),
-                ListTile(
-                  title: Text(l(context).openInBrowser),
-                  onTap: () => openWebpagePrimary(context, widget.openLinkUri!),
-                ),
-                ListTile(
-                  title: Text(l(context).share),
-                  onTap: () => shareUri(widget.openLinkUri!),
-                ),
-                if (widget.domain != null)
+                          : Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                              children: [
+                                ...votingWidgets,
+                                if (widget.notificationControlStatus != null &&
+                                    widget.onNotificationControlStatusChange !=
+                                        null &&
+                                    ((ac.serverSoftware ==
+                                                ServerSoftware.mbin &&
+                                            widget.contentTypeName !=
+                                                l(context).comment) ||
+                                        ac.serverSoftware ==
+                                            ServerSoftware.piefed))
+                                  Padding(
+                                    padding:
+                                        const EdgeInsets.fromLTRB(10, 0, 0, 0),
+                                    child: NotificationControlSegment(
+                                      widget.notificationControlStatus!,
+                                      (status) async {
+                                        widget.onNotificationControlStatusChange!(
+                                            status);
+                                        Navigator.pop(context);
+                                      },
+                                    ),
+                                  )
+                              ],
+                            );
+                    }),
+                  ),
                   ListTile(
-                    title: Text(l(context).moreFrom(widget.domain!)),
-                    onTap: () => Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (context) => DomainScreen(
-                          widget.domainIdOnClick!,
+                    title: Text(l(context).openInBrowser),
+                    onTap: () =>
+                        openWebpagePrimary(context, widget.openLinkUri!),
+                  ),
+                  ListTile(
+                    title: Text(l(context).share),
+                    onTap: () => shareUri(widget.openLinkUri!),
+                  ),
+                  if (widget.domain != null)
+                    ListTile(
+                      title: Text(l(context).moreFrom(widget.domain!)),
+                      onTap: () => Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (context) => DomainScreen(
+                            widget.domainIdOnClick!,
+                          ),
                         ),
                       ),
                     ),
-                  ),
-                if (widget.activeBookmarkLists != null &&
-                    widget.loadPossibleBookmarkLists != null &&
-                    widget.onAddBookmarkToList != null &&
-                    widget.onRemoveBookmarkFromList != null)
-                  ListTile(
-                    title: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text(l(context).bookmark),
-                        const Icon(
-                          Symbols.arrow_forward_rounded
-                        )
-                      ]
+                  if (widget.activeBookmarkLists != null &&
+                      widget.loadPossibleBookmarkLists != null &&
+                      widget.onAddBookmarkToList != null &&
+                      widget.onRemoveBookmarkFromList != null)
+                    ListTile(
+                      title: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(l(context).bookmark),
+                            const Icon(Symbols.arrow_forward_rounded)
+                          ]),
+                      onTap: () => showBookmarksMenu(context, widget),
                     ),
-                    onTap: () => showBookmarksMenu(context, widget),
-                  ),
-                if (widget.onMarkAsRead != null)
-                  ListTile(
-                    title: Text(widget.read ? l(context).action_markUnread : l(context).action_markRead),
-                    onTap: () {
-                      widget.onMarkAsRead!();
-                      Navigator.of(context).pop();
-                    },
-                  ),
-                if (widget.onReport != null)
-                  ListTile(
-                    title: Text(l(context).report),
-                    onTap: () async {
-                      final reportReason =
-                          await reportContent(context, widget.contentTypeName);
+                  if (widget.onMarkAsRead != null)
+                    ListTile(
+                      title: Text(widget.read
+                          ? l(context).action_markUnread
+                          : l(context).action_markRead),
+                      onTap: () {
+                        widget.onMarkAsRead!();
+                        Navigator.of(context).pop();
+                      },
+                    ),
+                  if (widget.onReport != null)
+                    ListTile(
+                      title: Text(l(context).report),
+                      onTap: () async {
+                        final reportReason = await reportContent(
+                            context, widget.contentTypeName);
 
-                      if (reportReason != null) {
-                        await widget.onReport!(reportReason);
-                      }
-                    },
-                  ),
-                if (widget.onEdit != null && onEdit != null)
-                  ListTile(
-                    title: Text(l(context).edit),
-                    onTap: () {
-                      onEdit();
-                      Navigator.pop(context);
-                    },
-                  ),
-                if (widget.onDelete != null)
-                  ListTile(
-                    title: Text(l(context).delete),
-                    onTap: () {
-                      // Don't show dialog if askBeforeDeleting is disabled
-                      if (!context.read<AppController>().profile.askBeforeDeleting) {
-                        widget.onDelete!();
+                        if (reportReason != null) {
+                          await widget.onReport!(reportReason);
+                        }
+                      },
+                    ),
+                  if (widget.onEdit != null && onEdit != null)
+                    ListTile(
+                      title: Text(l(context).edit),
+                      onTap: () {
+                        onEdit();
                         Navigator.pop(context);
-                        return;
-                      }
+                      },
+                    ),
+                  if (widget.onDelete != null)
+                    ListTile(
+                      title: Text(l(context).delete),
+                      onTap: () {
+                        // Don't show dialog if askBeforeDeleting is disabled
+                        if (!context
+                            .read<AppController>()
+                            .profile
+                            .askBeforeDeleting) {
+                          widget.onDelete!();
+                          Navigator.pop(context);
+                          return;
+                        }
 
-                      showDialog<bool>(
+                        showDialog<bool>(
+                          context: context,
+                          builder: (BuildContext context) => AlertDialog(
+                            title: Text(
+                                l(context).deleteX(widget.contentTypeName)),
+                            actions: <Widget>[
+                              OutlinedButton(
+                                onPressed: () => Navigator.pop(context),
+                                child: Text(l(context).cancel),
+                              ),
+                              LoadingFilledButton(
+                                onPressed: () async {
+                                  await widget.onDelete!();
+
+                                  if (!context.mounted) return;
+                                  Navigator.pop(context);
+                                  Navigator.pop(context);
+                                },
+                                label: Text(l(context).delete),
+                                uesHaptics: true,
+                              ),
+                            ],
+                            actionsOverflowAlignment:
+                                OverflowBarAlignment.center,
+                            actionsOverflowButtonSpacing: 8,
+                            actionsOverflowDirection: VerticalDirection.up,
+                          ),
+                        );
+                      },
+                    ),
+                  if (widget.body != null)
+                    ListTile(
+                      title: Text(l(context).viewSource),
+                      onTap: () => showDialog(
                         context: context,
-                        builder: (BuildContext context) => AlertDialog(
-                          title: Text(l(context).deleteX(widget.contentTypeName)),
-                          actions: <Widget>[
+                        builder: (context) => AlertDialog(
+                          title: Text(l(context).viewSource),
+                          content: Card.outlined(
+                            margin: EdgeInsets.zero,
+                            child: Padding(
+                              padding: const EdgeInsets.all(8),
+                              child: SelectableText(widget.body!),
+                            ),
+                          ),
+                          actions: [
                             OutlinedButton(
                               onPressed: () => Navigator.pop(context),
-                              child: Text(l(context).cancel),
+                              child: Text(l(context).close),
                             ),
-                            LoadingFilledButton(
+                            LoadingTonalButton(
                               onPressed: () async {
-                                await widget.onDelete!();
+                                await Clipboard.setData(
+                                  ClipboardData(text: widget.body!),
+                                );
 
                                 if (!context.mounted) return;
                                 Navigator.pop(context);
-                                Navigator.pop(context);
                               },
-                              label: Text(l(context).delete),
-                              uesHaptics: true,
+                              label: Text(l(context).copy),
                             ),
                           ],
-                          actionsOverflowAlignment: OverflowBarAlignment.center,
-                          actionsOverflowButtonSpacing: 8,
-                          actionsOverflowDirection: VerticalDirection.up,
                         ),
-                      );
-                    },
-                  ),
-                if (widget.body != null)
-                  ListTile(
-                    title: Text(l(context).viewSource),
-                    onTap: () => showDialog(
-                      context: context,
-                      builder: (context) => AlertDialog(
-                        title: Text(l(context).viewSource),
-                        content: Card.outlined(
-                          margin: EdgeInsets.zero,
-                          child: Padding(
-                            padding: const EdgeInsets.all(8),
-                            child: SelectableText(widget.body!),
-                          ),
-                        ),
-                        actions: [
-                          OutlinedButton(
-                            onPressed: () => Navigator.pop(context),
-                            child: Text(l(context).close),
-                          ),
-                          LoadingTonalButton(
-                            onPressed: () async {
-                              await Clipboard.setData(
-                                ClipboardData(text: widget.body!),
-                              );
-
-                              if (!context.mounted) return;
-                              Navigator.pop(context);
-                            },
-                            label: Text(l(context).copy),
-                          ),
-                        ],
                       ),
                     ),
-                  ),
-                if (widget.body != null && onTranslate != null)
-                  LoadingListTile(
-                    title: Text('Translate'),
-                    onTap: () async {
-                      await onTranslate(ac.profile.defaultPostLanguage);
-                      if (!context.mounted) return;
-                      Navigator.pop(context);
-                    },
-                    trailing: LoadingIconButton(
-                      onPressed: () async {
-                        final langCode = await languageSelectionMenu(context)
-                          .askSelection(
-                          context, ac.selectedProfileValue.defaultPostLanguage);
-
-                        if (langCode == null) return;
-                        await onTranslate(langCode);
+                  if (widget.body != null && onTranslate != null)
+                    LoadingListTile(
+                      title: Text('Translate'),
+                      onTap: () async {
+                        await onTranslate(ac.profile.defaultPostLanguage);
                         if (!context.mounted) return;
                         Navigator.pop(context);
                       },
-                      icon: Icon(Symbols.arrow_forward_rounded)
+                      trailing: LoadingIconButton(
+                          onPressed: () async {
+                            final langCode =
+                                await languageSelectionMenu(context)
+                                    .askSelection(
+                                        context,
+                                        ac.selectedProfileValue
+                                            .defaultPostLanguage);
+
+                            if (langCode == null) return;
+                            await onTranslate(langCode);
+                            if (!context.mounted) return;
+                            Navigator.pop(context);
+                          },
+                          icon: Icon(Symbols.arrow_forward_rounded)),
                     ),
-                  ),
-                if (widget.onModeratePin != null ||
-                    widget.onModerateMarkNSFW != null ||
-                    widget.onModerateDelete != null ||
-                    widget.onModerateBan != null)
-                  ListTile(
-                    title: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text(l(context).moderate),
-                        const Icon(
-                            Symbols.arrow_forward_rounded
-                        )
-                      ]
+                  if (widget.onModeratePin != null ||
+                      widget.onModerateMarkNSFW != null ||
+                      widget.onModerateDelete != null ||
+                      widget.onModerateBan != null)
+                    ListTile(
+                      title: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(l(context).moderate),
+                            const Icon(Symbols.arrow_forward_rounded)
+                          ]),
+                      onTap: () => showModerateMenu(context, widget),
                     ),
-                    onTap: () => showModerateMenu(context, widget),
-                  ),
-              ],
-            )
-          )
-        )
-      ],
-    );
-  });
+                ],
+              ),
+            ),
+          ),
+        ],
+      );
+    },
+  );
 }
 
 void showBookmarksMenu(BuildContext context, ContentItem widget) async {
   final possibleBookMarkLists = await widget.loadPossibleBookmarkLists!();
   if (!context.mounted) return;
 
-  showModalBottomSheet(context: context, builder: (context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Padding(
-          padding: const EdgeInsets.all(12),
-          child: Text(l(context).bookmark,
-            style: Theme.of(context).textTheme.titleLarge,
-            textAlign: TextAlign.center,
+  showModalBottomSheet(
+    context: context,
+    builder: (context) {
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Text(
+              l(context).bookmark,
+              style: Theme.of(context).textTheme.titleLarge,
+              textAlign: TextAlign.center,
+            ),
           ),
-        ),
-        Flexible(
-          child: Padding(
-            padding: const EdgeInsets.all(20),
-            child: ListView(
-              shrinkWrap: true,
-              children: [
-                ...{
-                  ...widget.activeBookmarkLists!,
-                  ...possibleBookMarkLists
-                }.map(
-                  (listName) => widget.activeBookmarkLists!.contains(listName)
-                    ? ListTile(
-                      title: Text(l(context).bookmark_removeFromX(listName)),
-                      leading: const Icon(
-                        Symbols.bookmark_rounded,
-                        fill: 1
-                      ),
-                      onTap: () {
-                        widget.onRemoveBookmarkFromList!(listName);
-                        Navigator.pop(context);
-                        Navigator.pop(context);
-                      },
-                    )
-                    : ListTile(
-                      title: Text(l(context).bookmark_addToX(listName)),
-                      leading: const Icon(
-                        Symbols.bookmark_rounded,
-                        fill: 1
-                      ),
-                      onTap: () {
-                        widget.onAddBookmarkToList!(listName);
-                        Navigator.pop(context);
-                        Navigator.pop(context);
-                      }
-                    )
-                )
-              ]
-            )
-          )
-        ),
-      ]
-    );
-  });
+          Flexible(
+            child: Padding(
+              padding: const EdgeInsets.all(20),
+              child: ListView(
+                shrinkWrap: true,
+                children: [
+                  ...{...widget.activeBookmarkLists!, ...possibleBookMarkLists}
+                      .map(
+                    (listName) => widget.activeBookmarkLists!.contains(listName)
+                        ? ListTile(
+                            title:
+                                Text(l(context).bookmark_removeFromX(listName)),
+                            leading:
+                                const Icon(Symbols.bookmark_rounded, fill: 1),
+                            onTap: () {
+                              widget.onRemoveBookmarkFromList!(listName);
+                              Navigator.pop(context);
+                              Navigator.pop(context);
+                            },
+                          )
+                        : ListTile(
+                            title: Text(l(context).bookmark_addToX(listName)),
+                            leading:
+                                const Icon(Symbols.bookmark_rounded, fill: 1),
+                            onTap: () {
+                              widget.onAddBookmarkToList!(listName);
+                              Navigator.pop(context);
+                              Navigator.pop(context);
+                            },
+                          ),
+                  )
+                ],
+              ),
+            ),
+          ),
+        ],
+      );
+    },
+  );
 }
 
 void showModerateMenu(BuildContext context, ContentItem widget) {
-  showModalBottomSheet(context: context, builder: (context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Padding(
-          padding: const EdgeInsets.all(12),
-          child: Text(l(context).moderate,
-            style: Theme.of(context).textTheme.titleLarge,
-            textAlign: TextAlign.center,
+  showModalBottomSheet(
+    context: context,
+    builder: (context) {
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Text(
+              l(context).moderate,
+              style: Theme.of(context).textTheme.titleLarge,
+              textAlign: TextAlign.center,
+            ),
           ),
-        ),
-        Flexible(
-          child: Padding(
-            padding: const EdgeInsets.all(20),
-            child: ListView(
-              shrinkWrap: true,
-              children: [
-                ListTile(
-                  title: Text(l(context).pin),
-                  onTap: () {
-                    widget.onModeratePin!();
-                    Navigator.pop(context);
-                    Navigator.pop(context);
-                  },
-                ),
-                ListTile(
-                  title: Text(l(context).notSafeForWork_mark),
-                  onTap: () {
-                    widget.onModerateMarkNSFW!();
-                    Navigator.pop(context);
-                    Navigator.pop(context);
-                  },
-                ),
-                ListTile(
-                  title: Text(l(context).delete),
-                  onTap: () {
-                    widget.onModerateDelete!();
-                    Navigator.pop(context);
-                    Navigator.pop(context);
-                  },
-                ),
-                ListTile(
-                  title: Text(l(context).banUser),
-                  onTap: () {
-                    Navigator.pop(context);
-                    Navigator.pop(context);
-                    widget.onModerateBan!();
-                  },
-                ),
-              ]
-            )
-          )
-        ),
-      ]
-    );
-  });
+          Flexible(
+            child: Padding(
+              padding: const EdgeInsets.all(20),
+              child: ListView(
+                shrinkWrap: true,
+                children: [
+                  ListTile(
+                    title: Text(l(context).pin),
+                    onTap: () {
+                      widget.onModeratePin!();
+                      Navigator.pop(context);
+                      Navigator.pop(context);
+                    },
+                  ),
+                  ListTile(
+                    title: Text(l(context).notSafeForWork_mark),
+                    onTap: () {
+                      widget.onModerateMarkNSFW!();
+                      Navigator.pop(context);
+                      Navigator.pop(context);
+                    },
+                  ),
+                  ListTile(
+                    title: Text(l(context).delete),
+                    onTap: () {
+                      widget.onModerateDelete!();
+                      Navigator.pop(context);
+                      Navigator.pop(context);
+                    },
+                  ),
+                  ListTile(
+                    title: Text(l(context).banUser),
+                    onTap: () {
+                      Navigator.pop(context);
+                      Navigator.pop(context);
+                      widget.onModerateBan!();
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      );
+    },
+  );
 }


### PR DESCRIPTION
- Add mark as read db postType, to support both `thread` and `microblog` types.
- Use a light font weight for read posts in feed instead of darkening colors
- Remove mark as read post delay when viewing. I didn't receive any errors once the `Future.delay` line was removed, but we can certainly add it back if it does pose a problem.
- And of course, the Dart formatter has been run, which has created those large diffs.