### PR TITLE
Small fixes for videos embedded in markdown

### DIFF
--- a/lib/src/widgets/markdown/markdown.dart
+++ b/lib/src/widgets/markdown/markdown.dart
@@ -4,6 +4,7 @@ import 'package:interstellar/src/models/image.dart';
 import 'package:interstellar/src/widgets/image.dart';
 import 'package:interstellar/src/widgets/markdown/markdown_config_share.dart';
 import 'package:interstellar/src/widgets/open_webpage.dart';
+import 'package:interstellar/src/widgets/video.dart';
 
 import './markdown_mention.dart';
 import './markdown_spoiler.dart';
@@ -40,6 +41,9 @@ class Markdown extends StatelessWidget {
         }
       },
       imageBuilder: (uri, title, alt) {
+        if (uri.path.split('.').last == 'mp4') {
+          return VideoPlayer(uri);
+        }
         return AdvancedImage(
           ImageModel(
             src: uri.toString(),

--- a/lib/src/widgets/markdown/markdown_video.dart
+++ b/lib/src/widgets/markdown/markdown_video.dart
@@ -37,7 +37,6 @@ class YoutubeEmbedSyntax extends md.InlineSyntax {
         String.fromCharCode(parser.charAt(parser.pos)) == '[';
     bool isAutoLink = String.fromCharCode(parser.charAt(parser.pos)) == '<';
     if (isAutoLink) {
-     parser.consume(1);
      startMatchPos += 1;
     }
 
@@ -59,7 +58,7 @@ class YoutubeEmbedSyntax extends md.InlineSyntax {
       }
     }
     if (isAutoLink && String.fromCharCode(parser.charAt(match.end)) == '>') {
-      parser.consume(1);
+      parser.consume(2);
       startMatchPos += 1;
     }
 


### PR DESCRIPTION
Fix consuming parts of autolink tag if link is not valid youtube link.
Handle case where links to mp4s are treated as images.