### PR TITLE
Fix search input not losing focus when tapping elsewhere on screen.

### DIFF
--- a/lib/src/screens/explore/explore_screen.dart
+++ b/lib/src/screens/explore/explore_screen.dart
@@ -196,6 +196,9 @@ class _ExploreScreenState extends State<ExploreScreen>
                           filled: true,
                           hintText: l(context).searchTheFediverse,
                         ),
+                        onTapOutside: (event) {
+                          FocusManager.instance.primaryFocus?.unfocus();
+                        },
                       ),
                       const SizedBox(height: 12),
                       Row(


### PR DESCRIPTION
Whenever I searched for something, opened a result then navigated back to the explore screen the text input would retake focus and reopen the keyboard. This should fix that.