### PR TITLE
Notifications Support for Piefed

### DIFF
--- a/lib/src/api/notifications.dart
+++ b/lib/src/api/notifications.dart
@@ -62,7 +62,13 @@ class APINotifications {
             nextPage: lemmyCalcNextIntPage(result.items, page));
 
       case ServerSoftware.piefed:
-        throw UnimplementedError();
+        final path =
+            '/user/notifications/${filter == NotificationsFilter.new_ ? 'new' : (filter?.name ?? 'all')}';
+        final query = {'p': page};
+
+        final response = await client.get(path, queryParams: query);
+
+        return NotificationListModel.fromPiefed(response.bodyJson);
     }
   }
 
@@ -158,7 +164,12 @@ class APINotifications {
         };
 
       case ServerSoftware.piefed:
-        throw UnimplementedError();
+        final path =
+            '/user/notifications/$notificationId/${readState ? 'read' : 'unread'}';
+
+        final response = await client.put(path);
+
+        return NotificationModel.fromPiefed(response.bodyJson);
     }
   }
 

--- a/lib/src/api/notifications.dart
+++ b/lib/src/api/notifications.dart
@@ -63,9 +63,10 @@ class APINotifications {
 
       case ServerSoftware.piefed:
         final path = '/user/notifications';
-        final status = filter == NotificationsFilter.new_
-            ? 'new'
-            : (filter?.name ?? 'all');
+        String status = 'All'; // default to All
+        if (filter == NotificationsFilter.new_) status = 'New';
+        if (filter == NotificationsFilter.read) status = 'Read';
+
         final query = {'page': page, 'status_request': status};
 
         final response = await client.get(path, queryParams: query);
@@ -174,13 +175,10 @@ class APINotifications {
 
       case ServerSoftware.piefed:
         final path = '/user/notification_state';
-        final notifId = notificationId;
-        final query = {
-          'notif_id': notifId.toString(),
-          'read_state': readState.toString()
-        };
 
-        final response = await client.put(path, queryParams: query);
+        final body = {'notif_id': notificationId, 'read_state': readState};
+
+        final response = await client.put(path, body: body);
 
         return NotificationModel.fromPiefed(response.bodyJson);
     }

--- a/lib/src/api/notifications.dart
+++ b/lib/src/api/notifications.dart
@@ -63,9 +63,11 @@ class APINotifications {
 
       case ServerSoftware.piefed:
         final path = '/user/notifications';
-        String status = 'All'; // default to All
-        if (filter == NotificationsFilter.new_) status = 'New';
-        if (filter == NotificationsFilter.read) status = 'Read';
+        final status = switch (filter) {
+          NotificationsFilter.new_ => 'New',
+          NotificationsFilter.read => 'Read',
+          NotificationsFilter.all || null => 'All',
+        };
 
         final query = {'page': page, 'status_request': status};
 

--- a/lib/src/api/notifications.dart
+++ b/lib/src/api/notifications.dart
@@ -93,7 +93,11 @@ class APINotifications {
             (response.bodyJson['private_messages'] as int);
 
       case ServerSoftware.piefed:
-        throw UnimplementedError();
+        const path = '/user/notifications_count';
+
+        final response = await client.get(path);
+
+        return response.bodyJson['count'] as int;
     }
   }
 
@@ -114,7 +118,11 @@ class APINotifications {
         return;
 
       case ServerSoftware.piefed:
-        throw UnimplementedError();
+        const path = '/user/mark_all_notifications_read';
+
+        final response = await client.put(path);
+
+        return;
     }
   }
 

--- a/lib/src/api/notifications.dart
+++ b/lib/src/api/notifications.dart
@@ -62,9 +62,11 @@ class APINotifications {
             nextPage: lemmyCalcNextIntPage(result.items, page));
 
       case ServerSoftware.piefed:
-        final path =
-            '/user/notifications/${filter == NotificationsFilter.new_ ? 'new' : (filter?.name ?? 'all')}';
-        final query = {'p': page};
+        final path = '/user/notifications';
+        final status = filter == NotificationsFilter.new_
+            ? 'new'
+            : (filter?.name ?? 'all');
+        final query = {'page': page, 'status_request': status};
 
         final response = await client.get(path, queryParams: query);
 
@@ -125,7 +127,6 @@ class APINotifications {
       case ServerSoftware.mbin:
         final path =
             '/notifications/$notificationId/${readState ? 'read' : 'unread'}';
-
         final response = await client.put(path);
 
         return NotificationModel.fromMbin(response.bodyJson);
@@ -164,10 +165,14 @@ class APINotifications {
         };
 
       case ServerSoftware.piefed:
-        final path =
-            '/user/notifications/$notificationId/${readState ? 'read' : 'unread'}';
+        final path = '/user/notification_state';
+        final notifId = notificationId;
+        final query = {
+          'notif_id': notifId.toString(),
+          'read_state': readState.toString()
+        };
 
-        final response = await client.put(path);
+        final response = await client.put(path, queryParams: query);
 
         return NotificationModel.fromPiefed(response.bodyJson);
     }

--- a/lib/src/models/notification.dart
+++ b/lib/src/models/notification.dart
@@ -38,11 +38,15 @@ class NotificationListModel with _$NotificationListModel {
 
   factory NotificationListModel.fromPiefed(JsonMap json) =>
       NotificationListModel(
-        items: (json['items'] as List<dynamic>)
-            .map((notif) => NotificationModel.fromPiefed(notif as JsonMap))
-            .toList(),
-        nextPage: mbinCalcNextPaginationPage(json['pagination'] as JsonMap),
-      ); // NotificationListModel
+          items: (json['items'] as List<dynamic>)
+              .map((notif) => NotificationModel.fromPiefed(notif as JsonMap))
+              .toList(),
+          // if next_page is None we have reached the end of the notifications
+          // so set nextPage to null. Otherwise set it to the next page number
+          // to request
+          nextPage: (json['next_page'] as String?) != 'None'
+              ? json['next_page'] as String?
+              : null);
 }
 
 @freezed

--- a/lib/src/models/notification.dart
+++ b/lib/src/models/notification.dart
@@ -38,10 +38,11 @@ class NotificationListModel with _$NotificationListModel {
 
   factory NotificationListModel.fromPiefed(JsonMap json) =>
       NotificationListModel(
-          items: (json['items'] as List<dynamic>)
-              .map((notif) => NotificationModel.fromPiefed(notif as JsonMap))
-              .toList(),
-          nextPage: null); // NotificationListModel
+        items: (json['items'] as List<dynamic>)
+            .map((notif) => NotificationModel.fromPiefed(notif as JsonMap))
+            .toList(),
+        nextPage: mbinCalcNextPaginationPage(json['pagination'] as JsonMap),
+      ); // NotificationListModel
 }
 
 @freezed

--- a/lib/src/models/notification.dart
+++ b/lib/src/models/notification.dart
@@ -116,7 +116,7 @@ class NotificationModel with _$NotificationModel {
     return NotificationModel(
         id: json['notif_id'] as int,
         type: notificationTypeMap[json['notif_subtype']],
-        isRead: json['status'] == 'read',
+        isRead: json['status'] == 'Read',
         subject: subject,
         creator: UserModel.fromPiefed(json['author'] as JsonMap));
   }

--- a/lib/src/models/notification.dart
+++ b/lib/src/models/notification.dart
@@ -35,6 +35,13 @@ class NotificationListModel with _$NotificationListModel {
         ],
         nextPage: null,
       );
+
+  factory NotificationListModel.fromPiefed(JsonMap json) =>
+      NotificationListModel(
+          items: (json['items'] as List<dynamic>)
+              .map((notif) => NotificationModel.fromPiefed(notif as JsonMap))
+              .toList(),
+          nextPage: null); // NotificationListModel
 }
 
 @freezed
@@ -97,12 +104,25 @@ class NotificationModel with _$NotificationModel {
       creator: UserModel.fromLemmy(json['creator'] as JsonMap),
     );
   }
+
+  factory NotificationModel.fromPiefed(JsonMap json) {
+    final subject = json;
+
+    return NotificationModel(
+        id: json['notif_id'] as int,
+        type: notificationTypeMap[json['notif_subtype']],
+        isRead: json['status'] == 'read',
+        subject: subject,
+        creator: UserModel.fromPiefed(json['author'] as JsonMap));
+  }
 }
 
 enum NotificationStatus { all, new_, read }
 
 enum NotificationType {
   mention,
+  postMention, //piefed
+  commentMention, //piefed
   reply, // Lemmy specific type
   entryCreated,
   entryEdited,
@@ -151,6 +171,14 @@ const notificationTypeMap = {
   'report_rejected_notification': NotificationType.reportRejected,
   'report_approved_notification': NotificationType.reportApproved,
   'new_signup': NotificationType.newSignup,
+  'new_post_from_followed_user': NotificationType.entryCreated,
+  'new_post_in_followed_community': NotificationType.entryCreated,
+  'new_post_in_followed_topic': NotificationType.entryCreated,
+  'top_level_comment_on_followed_post': NotificationType.entryCommentCreated,
+  'new_reply_on_followed_comment': NotificationType.entryCommentReply,
+  'new_post_in_followed_feed': NotificationType.entryCreated,
+  'comment_mention': NotificationType.commentMention,
+  'post_mention': NotificationType.postMention,
 };
 
 enum NotificationControlStatus {

--- a/lib/src/screens/account/notification/notification_item.dart
+++ b/lib/src/screens/account/notification/notification_item.dart
@@ -20,6 +20,8 @@ import 'notification_count_controller.dart';
 
 const notificationTitle = {
   NotificationType.mention: 'mentioned you',
+  NotificationType.postMention: 'mentioned you in a post',
+  NotificationType.commentMention: 'mentioned you in a comment',
   NotificationType.reply: 'replied to you',
   NotificationType.entryCreated: 'created a thread',
   NotificationType.entryEdited: 'edited your thread',

--- a/lib/src/screens/account/notification/notification_item.dart
+++ b/lib/src/screens/account/notification/notification_item.dart
@@ -82,8 +82,7 @@ class _NotificationItemState extends State<NotificationItem> {
             widget.item.subject['comment']['content'] as String,
           _ => throw Exception('invalid notification type for lemmy'),
         },
-      ServerSoftware.piefed =>
-        throw UnsupportedError('no notification support for piefed'),
+      ServerSoftware.piefed => (widget.item.subject['notif_body']) as String,
     };
 
     final void Function()? onTap = switch (software) {
@@ -165,8 +164,59 @@ class _NotificationItemState extends State<NotificationItem> {
             },
           _ => throw Exception('invalid notification type for lemmy'),
         },
-      ServerSoftware.piefed =>
-        throw UnsupportedError('no notification support for piefed'),
+      ServerSoftware.piefed => switch (widget.item.type!) {
+          NotificationType.entryCreated => () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => PostPage(
+                    postType: PostType.thread,
+                    postId: widget.item.subject['post_id'] as int,
+                  ),
+                ),
+              );
+            },
+          NotificationType.entryCommentCreated => () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => PostCommentScreen(
+                    PostType.thread,
+                    widget.item.subject['comment_id'] as int,
+                  ),
+                ),
+              );
+            },
+          NotificationType.entryCommentReply => () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => PostCommentScreen(
+                    PostType.thread,
+                    widget.item.subject['comment_id'] as int,
+                  ),
+                ),
+              );
+            },
+          NotificationType.postMention => () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => PostPage(
+                    postType: PostType.thread,
+                    postId: widget.item.subject['post_id'] as int,
+                  ),
+                ),
+              );
+            },
+          NotificationType.commentMention => () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => PostCommentScreen(
+                    PostType.thread,
+                    widget.item.subject['comment_id'] as int,
+                  ),
+                ),
+              );
+            },
+          _ => throw Exception('invalid notification type for piefed'),
+        }
     };
 
     return Card.outlined(

--- a/lib/src/screens/account/notification/notification_screen.dart
+++ b/lib/src/screens/account/notification/notification_screen.dart
@@ -194,7 +194,7 @@ SelectionMenu<NotificationsFilter> notificationFilterSelect(
           icon: Symbols.nest_eco_leaf_rounded,
         ),
         if (context.read<AppController>().serverSoftware ==
-                ServerSoftware.mbin &&
+                ServerSoftware.mbin ||
             context.read<AppController>().serverSoftware ==
                 ServerSoftware.piefed)
           SelectionMenuItem(

--- a/lib/src/screens/account/notification/notification_screen.dart
+++ b/lib/src/screens/account/notification/notification_screen.dart
@@ -193,14 +193,10 @@ SelectionMenu<NotificationsFilter> notificationFilterSelect(
           title: l(context).filter_new,
           icon: Symbols.nest_eco_leaf_rounded,
         ),
-        if (context.read<AppController>().serverSoftware == ServerSoftware.mbin)
-          SelectionMenuItem(
-            value: NotificationsFilter.read,
-            title: l(context).filter_read,
-            icon: Symbols.mark_chat_read_rounded,
-          ),
         if (context.read<AppController>().serverSoftware ==
-            ServerSoftware.piefed)
+                ServerSoftware.mbin &&
+            context.read<AppController>().serverSoftware ==
+                ServerSoftware.piefed)
           SelectionMenuItem(
             value: NotificationsFilter.read,
             title: l(context).filter_read,

--- a/lib/src/screens/account/notification/notification_screen.dart
+++ b/lib/src/screens/account/notification/notification_screen.dart
@@ -199,5 +199,12 @@ SelectionMenu<NotificationsFilter> notificationFilterSelect(
             title: l(context).filter_read,
             icon: Symbols.mark_chat_read_rounded,
           ),
+        if (context.read<AppController>().serverSoftware ==
+            ServerSoftware.piefed)
+          SelectionMenuItem(
+            value: NotificationsFilter.read,
+            title: l(context).filter_read,
+            icon: Symbols.mark_chat_read_rounded,
+          ),
       ],
     );


### PR DESCRIPTION
This adds support for notifications for Piefed.

In coordination with this PR on Piefed: https://codeberg.org/rimu/pyfedi/pulls/615 (now merged), and https://codeberg.org/rimu/pyfedi/pulls/619.

It's mostly based on the way the `.fromMbin` functions are setup, except the NotificationItem model which does a switch on the notificationtype more like the lemmy way.

I tested it on my personal piefed instance and its working so far.

Works for the Linux client and the android app in my testing.