### PR TITLE
Fix posts not being darkened when marked as read.

### DIFF
--- a/lib/src/screens/feed/post_item.dart
+++ b/lib/src/screens/feed/post_item.dart
@@ -83,6 +83,7 @@ class _PostItemState extends State<PostItem> {
     return SuperHero(
       tag: widget.item.toString(),
       child: Material(
+        color: Colors.transparent,
         child: ContentItem(
           originInstance: getNameHost(context, widget.item.user.name),
           title: widget.item.title,


### PR DESCRIPTION
Fixes a bug introduced in #179 where the post items aren't darkened when marked as read. The Material widget is needed as an ancestor to the Inkwells in ContentItem during the animation but draws over the Card in the feed. Making transparent fixes the problem.