### PR TITLE
Add blur to markdown embedded images if post is nsfw.

### DIFF
--- a/lib/src/widgets/content_item/content_item.dart
+++ b/lib/src/widgets/content_item/content_item.dart
@@ -248,7 +248,8 @@ class _ContentItemState extends State<ContentItem> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Markdown(widget.body!, widget.originInstance),
+                  Markdown(widget.body!, widget.originInstance,
+                      nsfw: widget.isNSFW),
                   Divider(),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
@@ -260,7 +261,8 @@ class _ContentItemState extends State<ContentItem> {
                   ),
                   Divider(),
                   Markdown(widget.translation!.translations.text,
-                      widget.originInstance),
+                      widget.originInstance,
+                      nsfw: widget.isNSFW),
                 ],
               )
         // No translation is available
@@ -270,7 +272,8 @@ class _ContentItemState extends State<ContentItem> {
                 maxLines: 4,
                 overflow: TextOverflow.ellipsis,
               )
-            : Markdown(widget.body!, widget.originInstance);
+            : Markdown(widget.body!, widget.originInstance,
+                nsfw: widget.isNSFW);
   }
 
   Widget full() {

--- a/lib/src/widgets/markdown/markdown.dart
+++ b/lib/src/widgets/markdown/markdown.dart
@@ -15,11 +15,13 @@ class Markdown extends StatelessWidget {
   final String data;
   final String originInstance;
   final ThemeData? themeData;
+  final bool nsfw;
 
   const Markdown(
     this.data,
     this.originInstance, {
     this.themeData,
+    this.nsfw = false,
     super.key,
   });
 
@@ -53,6 +55,7 @@ class Markdown extends StatelessWidget {
             blurHashHeight: null,
           ),
           openTitle: title ?? '',
+          enableBlur: nsfw,
         );
       },
       inlineSyntaxes: [


### PR DESCRIPTION
Noticed some posts that were marked as nsfw but the embedded images weren't blurred only the attached image was. This should fix that. Happily it wasn't anything super weird, some people just mark everything as nsfw. 