### PR TITLE
Add full language support

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -172,7 +172,7 @@
     }
   },
   "settings_about": "About",
-  "settings_defaultPostLanguage": "Default post language",
+  "settings_defaultCreateLanguage": "Default post/comment creation language",
   "settings_useAccountLanguageFilter": "Use account language filter",
   "settings_useAccountLanguageFilter_help": "Please note: language filters only apply to \"All\" and explore feeds",
   "settings_customLanguageFilter": "Custom language filter",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -243,8 +243,6 @@
   "@settings_feedDefaults": {},
   "settings_notifications": "Notificaties",
   "@settings_notifications": {},
-  "settings_defaultPostLanguage": "Standaardtaal voor berichten",
-  "@settings_defaultPostLanguage": {},
   "settings_useAccountLanguageFilter": "Gebruik account taalfilter",
   "@settings_useAccountLanguageFilter": {},
   "settings_useAccountLanguageFilter_help": "Let op: taalfilters zijn alleen van toepassing op 'Alles' en op verkenningsfeeds",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -285,8 +285,6 @@
   "@settings_display": {},
   "settings_about": "Об",
   "@settings_about": {},
-  "settings_defaultPostLanguage": "Язык сообщения по умолчанию",
-  "@settings_defaultPostLanguage": {},
   "settings_themeMode_system": "система",
   "@settings_themeMode_system": {},
   "settings_themeMode_light": "Светлая",

--- a/lib/l10n/app_ta.arb
+++ b/lib/l10n/app_ta.arb
@@ -303,8 +303,6 @@
   },
   "settings_about": "பற்றி",
   "@settings_about": {},
-  "settings_defaultPostLanguage": "இயல்புநிலை இடுகை மொழி",
-  "@settings_defaultPostLanguage": {},
   "settings_useAccountLanguageFilter": "கணக்கு மொழி வடிகட்டியைப் பயன்படுத்தவும்",
   "@settings_useAccountLanguageFilter": {},
   "settings_useAccountLanguageFilter_help": "தயவுசெய்து கவனிக்கவும்: மொழி வடிப்பான்கள் \"அனைத்திற்கும்\" மட்டுமே பொருந்தும் மற்றும் ஊட்டங்களை ஆராயுங்கள்",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -265,8 +265,6 @@
   },
   "settings_about": "Hakkında",
   "@settings_about": {},
-  "settings_defaultPostLanguage": "Varsayılan gönderi dili",
-  "@settings_defaultPostLanguage": {},
   "settings_useAccountLanguageFilter": "Hesap dil filtresini kullan",
   "@settings_useAccountLanguageFilter": {},
   "settings_useAccountLanguageFilter_help": "Lütfen dikkat: dil filtreleri yalnızca \"Tümü\" ve keşfet akışlarına uygulanır",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -328,8 +328,6 @@
   },
   "settings_about": "关于",
   "@settings_about": {},
-  "settings_defaultPostLanguage": "默认发帖语言",
-  "@settings_defaultPostLanguage": {},
   "settings_useAccountLanguageFilter": "使用账号语言过滤",
   "@settings_useAccountLanguageFilter": {},
   "settings_useAccountLanguageFilter_help": "请注意：语言过滤仅适用于“所有”和探索信息流",

--- a/lib/src/api/comments.dart
+++ b/lib/src/api/comments.dart
@@ -96,7 +96,10 @@ class APIComments {
 
         final response = await client.get(path, queryParams: query);
 
-        return CommentListModel.fromLemmyToTree(response.bodyJson);
+        return CommentListModel.fromLemmyToTree(
+          response.bodyJson,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
 
       case ServerSoftware.piefed:
         const path = '/comment/list';
@@ -109,7 +112,10 @@ class APIComments {
 
         final response = await client.get(path, queryParams: query);
 
-        return CommentListModel.fromPiefedToTree(response.bodyJson);
+        return CommentListModel.fromPiefedToTree(
+          response.bodyJson,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
     }
   }
 
@@ -152,7 +158,10 @@ class APIComments {
           page,
         );
 
-        return CommentListModel.fromLemmyToFlat(json);
+        return CommentListModel.fromLemmyToFlat(
+          json,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
 
       case ServerSoftware.piefed:
         const path = '/user';
@@ -171,7 +180,10 @@ class APIComments {
           page,
         );
 
-        return CommentListModel.fromPiefedToFlat(json);
+        return CommentListModel.fromPiefedToFlat(
+          json,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
     }
   }
 
@@ -195,6 +207,7 @@ class APIComments {
             (item) => item['comment']['id'] == commentId,
           ),
           possibleChildrenJson: response.bodyJson['comments'] as List<dynamic>,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
         );
 
       case ServerSoftware.piefed:
@@ -208,6 +221,7 @@ class APIComments {
             (item) => item['comment']['id'] == commentId,
           ),
           possibleChildrenJson: response.bodyJson['comments'] as List<dynamic>,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
         );
     }
   }
@@ -238,6 +252,7 @@ class APIComments {
 
         return CommentModel.fromLemmy(
           response.bodyJson['comment_view'] as JsonMap,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
         );
 
       case ServerSoftware.piefed:
@@ -250,6 +265,7 @@ class APIComments {
 
         return CommentModel.fromPiefed(
           response.bodyJson['comment_view'] as JsonMap,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
         );
     }
   }
@@ -300,6 +316,7 @@ class APIComments {
 
         return CommentModel.fromLemmy(
           response.bodyJson['comment_view'] as JsonMap,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
         );
 
       case ServerSoftware.piefed:
@@ -312,6 +329,7 @@ class APIComments {
 
         return CommentModel.fromPiefed(
           response.bodyJson['comment_view'] as JsonMap,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
         );
     }
   }
@@ -339,6 +357,7 @@ class APIComments {
 
         return CommentModel.fromLemmy(
           response.bodyJson['comment_view'] as JsonMap,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
         );
 
       case ServerSoftware.piefed:
@@ -351,6 +370,7 @@ class APIComments {
 
         return CommentModel.fromPiefed(
           response.bodyJson['comment_view'] as JsonMap,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
         );
     }
   }

--- a/lib/src/api/comments.dart
+++ b/lib/src/api/comments.dart
@@ -292,13 +292,17 @@ class APIComments {
     int postId,
     String body, {
     int? parentCommentId,
+    required String lang,
   }) async {
     switch (client.software) {
       case ServerSoftware.mbin:
         final path =
             '/${_postTypeMbin[postType]}/$postId/comments${parentCommentId != null ? '/$parentCommentId/reply' : ''}';
 
-        final response = await client.post(path, body: {'body': body});
+        final response = await client.post(
+          path,
+          body: {'body': body, 'lang': lang},
+        );
 
         return CommentModel.fromMbin(response.bodyJson);
 
@@ -311,6 +315,7 @@ class APIComments {
             'content': body,
             'post_id': postId,
             'parent_id': parentCommentId,
+            'language_id': await client.languageIdFromCode(lang),
           },
         );
 
@@ -324,7 +329,12 @@ class APIComments {
 
         final response = await client.post(
           path,
-          body: {'body': body, 'post_id': postId, 'parent_id': parentCommentId},
+          body: {
+            'body': body,
+            'post_id': postId,
+            'parent_id': parentCommentId,
+            'language_id': await client.languageIdFromCode(lang),
+          },
         );
 
         return CommentModel.fromPiefed(

--- a/lib/src/api/moderation.dart
+++ b/lib/src/api/moderation.dart
@@ -42,7 +42,10 @@ class APIModeration {
           },
         );
 
-        return PostModel.fromPiefed(response.bodyJson['post_view'] as JsonMap);
+        return PostModel.fromPiefed(
+          response.bodyJson['post_view'] as JsonMap,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
     }
   }
 
@@ -72,7 +75,10 @@ class APIModeration {
 
         final response = await client.post(path, body: body);
 
-        return PostModel.fromPiefed(response.bodyJson);
+        return PostModel.fromPiefed(
+          response.bodyJson,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
     }
   }
 
@@ -104,7 +110,10 @@ class APIModeration {
           body: {'post_id': postId, 'removed': status, 'reason': 'Moderated'},
         );
 
-        return PostModel.fromPiefed(response.bodyJson['post_view'] as JsonMap);
+        return PostModel.fromPiefed(
+          response.bodyJson['post_view'] as JsonMap,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
     }
   }
 
@@ -139,6 +148,7 @@ class APIModeration {
 
         return CommentModel.fromPiefed(
           response.bodyJson['comment_view'] as JsonMap,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
         );
     }
   }

--- a/lib/src/api/search.dart
+++ b/lib/src/api/search.dart
@@ -50,7 +50,10 @@ class APISearch {
 
         json['next_page'] = nextPage;
 
-        return SearchListModel.fromLemmy(json);
+        return SearchListModel.fromLemmy(
+          json,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
 
       case ServerSoftware.piefed:
         const path = '/search';
@@ -79,7 +82,10 @@ class APISearch {
 
         json['next_page'] = nextPage;
 
-        return SearchListModel.fromPiefed(json);
+        return SearchListModel.fromPiefed(
+          json,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
     }
   }
 }

--- a/lib/src/api/threads.dart
+++ b/lib/src/api/threads.dart
@@ -90,7 +90,10 @@ class APIThreads {
             page,
           );
 
-          return PostListModel.fromLemmy(json);
+          return PostListModel.fromLemmy(
+            json,
+            langCodeIdPairs: await client.languageCodeIdPairs(),
+          );
         }
 
         const path = '/post/list';
@@ -112,7 +115,10 @@ class APIThreads {
 
         final response = await client.get(path, queryParams: query);
 
-        return PostListModel.fromLemmy(response.bodyJson);
+        return PostListModel.fromLemmy(
+          response.bodyJson,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
 
       case ServerSoftware.piefed:
         if (source == FeedSource.user) {
@@ -132,7 +138,10 @@ class APIThreads {
             page,
           );
 
-          return PostListModel.fromPiefed(json);
+          return PostListModel.fromPiefed(
+            json,
+            langCodeIdPairs: await client.languageCodeIdPairs(),
+          );
         }
 
         const path = '/post/list';
@@ -158,7 +167,10 @@ class APIThreads {
 
         if (json['next_page'] == 'None') json['next_page'] = null;
 
-        return PostListModel.fromPiefed(json);
+        return PostListModel.fromPiefed(
+          json,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
     }
   }
 
@@ -177,7 +189,10 @@ class APIThreads {
 
         final response = await client.get(path, queryParams: query);
 
-        return PostModel.fromLemmy(response.bodyJson['post_view'] as JsonMap);
+        return PostModel.fromLemmy(
+          response.bodyJson['post_view'] as JsonMap,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
 
       case ServerSoftware.piefed:
         const path = '/post';
@@ -185,7 +200,10 @@ class APIThreads {
 
         final response = await client.get(path, queryParams: query);
 
-        return PostModel.fromPiefed(response.bodyJson['post_view'] as JsonMap);
+        return PostModel.fromPiefed(
+          response.bodyJson['post_view'] as JsonMap,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
     }
   }
 
@@ -206,7 +224,10 @@ class APIThreads {
           body: {'post_id': postId, 'score': newScore},
         );
 
-        return PostModel.fromLemmy(response.bodyJson['post_view'] as JsonMap);
+        return PostModel.fromLemmy(
+          response.bodyJson['post_view'] as JsonMap,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
 
       case ServerSoftware.piefed:
         final response = await client.post(
@@ -214,7 +235,10 @@ class APIThreads {
           body: {'post_id': postId, 'score': newScore},
         );
 
-        return PostModel.fromPiefed(response.bodyJson['post_view'] as JsonMap);
+        return PostModel.fromPiefed(
+          response.bodyJson['post_view'] as JsonMap,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
     }
   }
 
@@ -236,7 +260,7 @@ class APIThreads {
   }
 
   Future<PostModel> edit(
-    int entryID,
+    int postId,
     String title,
     bool? isOc,
     String body,
@@ -245,7 +269,7 @@ class APIThreads {
   ) async {
     switch (client.software) {
       case ServerSoftware.mbin:
-        final path = '/entry/$entryID';
+        final path = '/entry/$postId';
 
         final response = await client.put(
           path,
@@ -267,14 +291,17 @@ class APIThreads {
         final response = await client.put(
           path,
           body: {
-            'post_id': entryID,
+            'post_id': postId,
             'name': title,
             'body': body,
             'nsfw': isAdult,
           },
         );
 
-        return PostModel.fromLemmy(response.bodyJson['post_view'] as JsonMap);
+        return PostModel.fromLemmy(
+          response.bodyJson['post_view'] as JsonMap,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
 
       case ServerSoftware.piefed:
         const path = '/post';
@@ -282,14 +309,17 @@ class APIThreads {
         final response = await client.put(
           path,
           body: {
-            'post_id': entryID,
+            'post_id': postId,
             'name': title,
             'body': body,
             'nsfw': isAdult,
           },
         );
 
-        return PostModel.fromPiefed(response.bodyJson['post_view'] as JsonMap);
+        return PostModel.fromPiefed(
+          response.bodyJson['post_view'] as JsonMap,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
     }
   }
 
@@ -354,10 +384,14 @@ class APIThreads {
             'community_id': communityId,
             'body': body,
             'nsfw': isAdult,
+            'language_id': await client.languageIdFromCode(lang),
           },
         );
 
-        return PostModel.fromLemmy(response.bodyJson['post_view'] as JsonMap);
+        return PostModel.fromLemmy(
+          response.bodyJson['post_view'] as JsonMap,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
 
       case ServerSoftware.piefed:
         const path = '/post';
@@ -368,10 +402,14 @@ class APIThreads {
             'community_id': communityId,
             'body': body,
             'nsfw': isAdult,
+            'language_id': await client.languageIdFromCode(lang),
           },
         );
 
-        return PostModel.fromPiefed(response.bodyJson['post_view'] as JsonMap);
+        return PostModel.fromPiefed(
+          response.bodyJson['post_view'] as JsonMap,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
     }
   }
 
@@ -414,10 +452,14 @@ class APIThreads {
             'url': url,
             'body': body,
             'nsfw': isAdult,
+            'language_id': await client.languageIdFromCode(lang),
           },
         );
 
-        return PostModel.fromLemmy(response.bodyJson['post_view'] as JsonMap);
+        return PostModel.fromLemmy(
+          response.bodyJson['post_view'] as JsonMap,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
 
       case ServerSoftware.piefed:
         const path = '/post';
@@ -429,10 +471,14 @@ class APIThreads {
             'url': url,
             'body': body,
             'nsfw': isAdult,
+            'language_id': await client.languageIdFromCode(lang),
           },
         );
 
-        return PostModel.fromPiefed(response.bodyJson['post_view'] as JsonMap);
+        return PostModel.fromPiefed(
+          response.bodyJson['post_view'] as JsonMap,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
     }
   }
 
@@ -507,10 +553,14 @@ class APIThreads {
             'body': body,
             'nsfw': isAdult,
             'alt_text': nullIfEmpty(alt),
+            'language_id': await client.languageIdFromCode(lang),
           },
         );
 
-        return PostModel.fromLemmy(response.bodyJson['post_view'] as JsonMap);
+        return PostModel.fromLemmy(
+          response.bodyJson['post_view'] as JsonMap,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
 
       case ServerSoftware.piefed:
         const uploadPath = '/upload/image';
@@ -541,10 +591,14 @@ class APIThreads {
             'url': imageUrl,
             'body': body,
             'nsfw': isAdult,
+            'language_id': await client.languageIdFromCode(lang),
           },
         );
 
-        return PostModel.fromPiefed(response.bodyJson['post_view'] as JsonMap);
+        return PostModel.fromPiefed(
+          response.bodyJson['post_view'] as JsonMap,
+          langCodeIdPairs: await client.languageCodeIdPairs(),
+        );
     }
   }
 

--- a/lib/src/controller/profile.dart
+++ b/lib/src/controller/profile.dart
@@ -22,7 +22,7 @@ class ProfileRequired with _$ProfileRequired {
     // If the autoSwitchAccount key is ever changed, be sure to update the AppController code that removes accounts, which references this key.
     required String? autoSwitchAccount,
     // Behavior settings
-    required String defaultPostLanguage,
+    required String defaultCreateLanguage,
     required bool useAccountLanguageFilter,
     required List<String> customLanguageFilter,
     required bool disableTabSwiping,
@@ -81,8 +81,8 @@ class ProfileRequired with _$ProfileRequired {
     ProfileOptional? profile,
   ) => ProfileRequired(
     autoSwitchAccount: profile?.autoSwitchAccount,
-    defaultPostLanguage:
-        profile?.defaultPostLanguage ?? defaultProfile.defaultPostLanguage,
+    defaultCreateLanguage:
+        profile?.defaultCreateLanguage ?? defaultProfile.defaultCreateLanguage,
     useAccountLanguageFilter:
         profile?.useAccountLanguageFilter ??
         defaultProfile.useAccountLanguageFilter,
@@ -176,7 +176,7 @@ class ProfileRequired with _$ProfileRequired {
 
   static const defaultProfile = ProfileRequired(
     autoSwitchAccount: null,
-    defaultPostLanguage: 'en',
+    defaultCreateLanguage: 'en',
     useAccountLanguageFilter: true,
     customLanguageFilter: [],
     disableTabSwiping: false,
@@ -233,7 +233,7 @@ class ProfileOptional with _$ProfileOptional {
   const factory ProfileOptional({
     required String? autoSwitchAccount,
     // Behavior settings
-    required String? defaultPostLanguage,
+    required String? defaultCreateLanguage,
     required bool? useAccountLanguageFilter,
     required List<String>? customLanguageFilter,
     required bool? disableTabSwiping,
@@ -289,7 +289,7 @@ class ProfileOptional with _$ProfileOptional {
 
   static const nullProfile = ProfileOptional(
     autoSwitchAccount: null,
-    defaultPostLanguage: null,
+    defaultCreateLanguage: null,
     useAccountLanguageFilter: null,
     customLanguageFilter: null,
     disableTabSwiping: null,
@@ -341,7 +341,8 @@ class ProfileOptional with _$ProfileOptional {
 
     return ProfileOptional(
       autoSwitchAccount: other.autoSwitchAccount,
-      defaultPostLanguage: other.defaultPostLanguage ?? defaultPostLanguage,
+      defaultCreateLanguage:
+          other.defaultCreateLanguage ?? defaultCreateLanguage,
       useAccountLanguageFilter:
           other.useAccountLanguageFilter ?? useAccountLanguageFilter,
       customLanguageFilter: other.customLanguageFilter ?? customLanguageFilter,

--- a/lib/src/models/post.dart
+++ b/lib/src/models/post.dart
@@ -32,18 +32,36 @@ class PostListModel with _$PostListModel {
     nextPage: mbinCalcNextPaginationPage(json['pagination'] as JsonMap),
   );
 
-  factory PostListModel.fromLemmy(JsonMap json) => PostListModel(
+  factory PostListModel.fromLemmy(
+    JsonMap json, {
+    required List<(String, int)> langCodeIdPairs,
+  }) => PostListModel(
     items: (json['posts'] as List<dynamic>)
-        .map((post) => PostModel.fromLemmy(post as JsonMap))
+        .map(
+          (post) => PostModel.fromLemmy(
+            post as JsonMap,
+            langCodeIdPairs: langCodeIdPairs,
+          ),
+        )
         .toList(),
     nextPage: json['next_page'] as String?,
   );
 
-  factory PostListModel.fromPiefed(JsonMap json) => PostListModel(
+  factory PostListModel.fromPiefed(
+    JsonMap json, {
+    required List<(String, int)> langCodeIdPairs,
+  }) => PostListModel(
     items: (json['posts'] as List<dynamic>)
-        .map((post) => PostModel.fromPiefed(post as JsonMap))
+        .map(
+          (post) => PostModel.fromPiefed(
+            post as JsonMap,
+            langCodeIdPairs: langCodeIdPairs,
+          ),
+        )
         .toList(),
-    nextPage: json['next_page'] as String?,
+    nextPage: (json['next_page'] as String?) != 'None'
+        ? json['next_page'] as String?
+        : null,
   );
 }
 
@@ -156,7 +174,10 @@ class PostModel with _$PostModel {
     read: false,
   );
 
-  factory PostModel.fromLemmy(JsonMap json) {
+  factory PostModel.fromLemmy(
+    JsonMap json, {
+    required List<(String, int)> langCodeIdPairs,
+  }) {
     final lemmyPost = json['post'] as JsonMap;
     final lemmyCounts = json['counts'] as JsonMap;
 
@@ -178,7 +199,10 @@ class PostModel with _$PostModel {
         lemmyPost['alt_text'] as String?,
       ),
       body: lemmyPost['body'] as String?,
-      lang: null,
+      lang: langCodeIdPairs
+          .where((pair) => pair.$2 == lemmyPost['language_id'] as int)
+          .firstOrNull
+          ?.$1,
       numComments: lemmyCounts['comments'] as int,
       upvotes: lemmyCounts['upvotes'] as int,
       downvotes: lemmyCounts['downvotes'] as int,
@@ -204,7 +228,10 @@ class PostModel with _$PostModel {
     );
   }
 
-  factory PostModel.fromPiefed(JsonMap json) {
+  factory PostModel.fromPiefed(
+    JsonMap json, {
+    required List<(String, int)> langCodeIdPairs,
+  }) {
     final piefedPost = json['post'] as JsonMap;
     final piefedCounts = json['counts'] as JsonMap;
 
@@ -226,7 +253,10 @@ class PostModel with _$PostModel {
         piefedPost['alt_text'] as String?,
       ),
       body: piefedPost['body'] as String?,
-      lang: null,
+      lang: langCodeIdPairs
+          .where((pair) => pair.$2 == piefedPost['language_id'] as int)
+          .firstOrNull
+          ?.$1,
       numComments: piefedCounts['comments'] as int,
       upvotes: piefedCounts['upvotes'] as int,
       downvotes: piefedCounts['downvotes'] as int,

--- a/lib/src/models/search.dart
+++ b/lib/src/models/search.dart
@@ -43,7 +43,10 @@ class SearchListModel with _$SearchListModel {
     );
   }
 
-  factory SearchListModel.fromLemmy(Map<String, dynamic> json) {
+  factory SearchListModel.fromLemmy(
+    Map<String, dynamic> json, {
+    required List<(String, int)> langCodeIdPairs,
+  }) {
     List<Object> items = [];
 
     for (var user in json['users']) {
@@ -55,11 +58,18 @@ class SearchListModel with _$SearchListModel {
     }
 
     for (var post in json['posts']) {
-      items.add(PostModel.fromLemmy(post as JsonMap));
+      items.add(
+        PostModel.fromLemmy(post as JsonMap, langCodeIdPairs: langCodeIdPairs),
+      );
     }
 
     for (var comment in json['comments']) {
-      items.add(CommentModel.fromLemmy(comment as JsonMap));
+      items.add(
+        CommentModel.fromLemmy(
+          comment as JsonMap,
+          langCodeIdPairs: langCodeIdPairs,
+        ),
+      );
     }
 
     return SearchListModel(
@@ -68,7 +78,10 @@ class SearchListModel with _$SearchListModel {
     );
   }
 
-  factory SearchListModel.fromPiefed(Map<String, dynamic> json) {
+  factory SearchListModel.fromPiefed(
+    Map<String, dynamic> json, {
+    required List<(String, int)> langCodeIdPairs,
+  }) {
     List<Object> items = [];
 
     for (var user in json['users']) {
@@ -80,11 +93,18 @@ class SearchListModel with _$SearchListModel {
     }
 
     for (var post in json['posts']) {
-      items.add(PostModel.fromPiefed(post as JsonMap));
+      items.add(
+        PostModel.fromPiefed(post as JsonMap, langCodeIdPairs: langCodeIdPairs),
+      );
     }
 
     for (var comment in json['comments']) {
-      items.add(CommentModel.fromPiefed(comment as JsonMap));
+      items.add(
+        CommentModel.fromPiefed(
+          comment as JsonMap,
+          langCodeIdPairs: langCodeIdPairs,
+        ),
+      );
     }
 
     return SearchListModel(

--- a/lib/src/screens/feed/create_screen.dart
+++ b/lib/src/screens/feed/create_screen.dart
@@ -49,7 +49,7 @@ class _CreateScreenState extends State<CreateScreen> {
   void initState() {
     super.initState();
 
-    _lang = context.read<AppController>().profile.defaultPostLanguage;
+    _lang = context.read<AppController>().profile.defaultCreateLanguage;
 
     if (widget.initCommunity != null) _community = widget.initCommunity;
     if (widget.initTitle != null) _titleTextController.text = widget.initTitle!;

--- a/lib/src/screens/feed/feed_screen.dart
+++ b/lib/src/screens/feed/feed_screen.dart
@@ -1225,12 +1225,20 @@ class _FeedScreenBodyState extends State<FeedScreenBody>
                                     _pagingController.itemList = newList;
                                   });
                                 },
-                                onReply: whenLoggedIn(context, (body) async {
+                                onReply: whenLoggedIn(context, (
+                                  body,
+                                  lang,
+                                ) async {
                                   await context
                                       .read<AppController>()
                                       .api
                                       .comments
-                                      .create(item.type, item.id, body);
+                                      .create(
+                                        item.type,
+                                        item.id,
+                                        body,
+                                        lang: lang,
+                                      );
                                 }),
                                 onTap: onPostTap,
                                 filterListWarnings:
@@ -1263,12 +1271,12 @@ class _FeedScreenBodyState extends State<FeedScreenBody>
                             },
                             onTap: onPostTap,
                             isPreview: true,
-                            onReply: whenLoggedIn(context, (body) async {
+                            onReply: whenLoggedIn(context, (body, lang) async {
                               await context
                                   .read<AppController>()
                                   .api
                                   .comments
-                                  .create(item.type, item.id, body);
+                                  .create(item.type, item.id, body, lang: lang);
                             }),
                             filterListWarnings:
                                 _filterListWarnings[(item.type, item.id)],

--- a/lib/src/screens/feed/post_comment.dart
+++ b/lib/src/screens/feed/post_comment.dart
@@ -52,10 +52,12 @@ class _PostCommentState extends State<PostComment> {
     super.initState();
     if (context.read<AppController>().profile.autoTranslate &&
         widget.comment.lang !=
-            context.read<AppController>().profile.defaultPostLanguage &&
+            context.read<AppController>().profile.defaultCreateLanguage &&
         widget.comment.body != null &&
         widget.comment.lang != null) {
-      getTranslation(context.read<AppController>().profile.defaultPostLanguage);
+      getTranslation(
+        context.read<AppController>().profile.defaultCreateLanguage,
+      );
     }
   }
 

--- a/lib/src/screens/feed/post_comment.dart
+++ b/lib/src/screens/feed/post_comment.dart
@@ -189,12 +189,13 @@ class _PostCommentState extends State<PostComment> {
         );
       }),
       contentTypeName: l(context).comment,
-      onReply: whenLoggedIn(context, (body) async {
+      onReply: whenLoggedIn(context, (body, lang) async {
         var newSubComment = await ac.api.comments.create(
           widget.comment.postType,
           widget.comment.postId,
           body,
           parentCommentId: widget.comment.id,
+          lang: lang,
         );
 
         widget.onUpdate(

--- a/lib/src/screens/feed/post_item.dart
+++ b/lib/src/screens/feed/post_item.dart
@@ -51,10 +51,12 @@ class _PostItemState extends State<PostItem> {
     super.initState();
     if (context.read<AppController>().profile.autoTranslate &&
         widget.item.lang !=
-            context.read<AppController>().profile.defaultPostLanguage &&
+            context.read<AppController>().profile.defaultCreateLanguage &&
         widget.item.body != null &&
         widget.item.lang != null) {
-      getTranslation(context.read<AppController>().profile.defaultPostLanguage);
+      getTranslation(
+        context.read<AppController>().profile.defaultCreateLanguage,
+      );
     }
   }
 

--- a/lib/src/screens/feed/post_item.dart
+++ b/lib/src/screens/feed/post_item.dart
@@ -29,7 +29,7 @@ class PostItem extends StatefulWidget {
 
   final PostModel item;
   final void Function(PostModel) onUpdate;
-  final Future<void> Function(String)? onReply;
+  final Future<void> Function(String body, String lang)? onReply;
   final Future<void> Function(String)? onEdit;
   final Future<void> Function()? onDelete;
   final void Function()? onTap;

--- a/lib/src/screens/feed/post_page.dart
+++ b/lib/src/screens/feed/post_page.dart
@@ -176,12 +176,12 @@ class _PostPageState extends State<PostPage> {
               child: PostItem(
                 post,
                 _onUpdate,
-                onReply: whenLoggedIn(context, (body) async {
+                onReply: whenLoggedIn(context, (body, lang) async {
                   var newComment = await context
                       .read<AppController>()
                       .api
                       .comments
-                      .create(post.type, post.id, body);
+                      .create(post.type, post.id, body, lang: lang);
                   var newList = _pagingController.itemList;
                   newList?.insert(0, newComment);
                   setState(() {

--- a/lib/src/screens/settings/behavior_screen.dart
+++ b/lib/src/screens/settings/behavior_screen.dart
@@ -24,7 +24,7 @@ class BehaviorSettingsScreen extends StatelessWidget {
         children: [
           ListTile(
             leading: const Icon(Symbols.translate_rounded),
-            title: Text(l(context).settings_defaultPostLanguage),
+            title: Text(l(context).settings_defaultCreateLanguage),
             subtitle: Text(
               getLanguageName(context, ac.profile.defaultCreateLanguage),
             ),

--- a/lib/src/screens/settings/behavior_screen.dart
+++ b/lib/src/screens/settings/behavior_screen.dart
@@ -26,19 +26,21 @@ class BehaviorSettingsScreen extends StatelessWidget {
             leading: const Icon(Symbols.translate_rounded),
             title: Text(l(context).settings_defaultPostLanguage),
             subtitle: Text(
-              getLanguageName(context, ac.profile.defaultPostLanguage),
+              getLanguageName(context, ac.profile.defaultCreateLanguage),
             ),
             onTap: () async {
               final langCode = await languageSelectionMenu(context)
                   .askSelection(
                     context,
-                    ac.selectedProfileValue.defaultPostLanguage,
+                    ac.selectedProfileValue.defaultCreateLanguage,
                   );
 
               if (langCode == null) return;
 
               ac.updateProfile(
-                ac.selectedProfileValue.copyWith(defaultPostLanguage: langCode),
+                ac.selectedProfileValue.copyWith(
+                  defaultCreateLanguage: langCode,
+                ),
               );
             },
           ),

--- a/lib/src/utils/language.dart
+++ b/lib/src/utils/language.dart
@@ -26,7 +26,8 @@ SelectionMenu<String> languageSelectionMenu(BuildContext context) =>
               title: getLanguageName(context, langTag),
             ),
           )
-          .toList(),
+          .toList()
+          ..sort((lhs, rhs) => lhs.title.compareTo(rhs.title)),
     );
 
 SelectionMenu<String> languageSelectionMenuAppSupported(BuildContext context) =>

--- a/lib/src/widgets/content_item/content_item.dart
+++ b/lib/src/widgets/content_item/content_item.dart
@@ -185,7 +185,10 @@ class _ContentItemState extends State<ContentItem> {
   void initState() {
     super.initState();
 
-    _replyLanguage = context.read<AppController>().profile.defaultPostLanguage;
+    _replyLanguage = context
+        .read<AppController>()
+        .profile
+        .defaultCreateLanguage;
   }
 
   @override

--- a/lib/src/widgets/content_item/content_item.dart
+++ b/lib/src/widgets/content_item/content_item.dart
@@ -583,6 +583,26 @@ class _ContentItemState extends State<ContentItem> {
                                           ),
                                         ),
                                       ),
+                                    if (widget.lang != null)
+                                      Padding(
+                                        padding: const EdgeInsets.only(
+                                          right: 10,
+                                        ),
+                                        child: Tooltip(
+                                          message: getLanguageName(
+                                            context,
+                                            widget.lang!,
+                                          ),
+                                          triggerMode: TooltipTriggerMode.tap,
+                                          child: Text(
+                                            widget.lang!,
+                                            style: const TextStyle(
+                                              color: Colors.purple,
+                                              fontWeight: FontWeight.bold,
+                                            ),
+                                          ),
+                                        ),
+                                      ),
                                     if (!widget.showCommunityFirst) ?userWidget,
                                     if (widget.showCommunityFirst)
                                       ?communityWidget,
@@ -1063,6 +1083,21 @@ class _ContentItemState extends State<ContentItem> {
                               l(context).originalContent_short,
                               style: const TextStyle(
                                 color: Colors.lightGreen,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                        ),
+                      if (widget.lang != null)
+                        Padding(
+                          padding: const EdgeInsets.only(right: 10),
+                          child: Tooltip(
+                            message: getLanguageName(context, widget.lang!),
+                            triggerMode: TooltipTriggerMode.tap,
+                            child: Text(
+                              widget.lang!,
+                              style: const TextStyle(
+                                color: Colors.purple,
                                 fontWeight: FontWeight.bold,
                               ),
                             ),

--- a/lib/src/widgets/content_item/content_item.dart
+++ b/lib/src/widgets/content_item/content_item.dart
@@ -594,7 +594,12 @@ class _ContentItemState extends State<ContentItem> {
                                           ),
                                         ),
                                       ),
-                                    if (widget.lang != null)
+                                    if (widget.lang != null &&
+                                        widget.lang !=
+                                            context
+                                                .read<AppController>()
+                                                .profile
+                                                .defaultCreateLanguage)
                                       Padding(
                                         padding: const EdgeInsets.only(
                                           right: 10,
@@ -1123,7 +1128,12 @@ class _ContentItemState extends State<ContentItem> {
                             ),
                           ),
                         ),
-                      if (widget.lang != null)
+                      if (widget.lang != null &&
+                          widget.lang !=
+                              context
+                                  .read<AppController>()
+                                  .profile
+                                  .defaultCreateLanguage)
                         Padding(
                           padding: const EdgeInsets.only(right: 10),
                           child: Tooltip(

--- a/lib/src/widgets/content_item/content_item.dart
+++ b/lib/src/widgets/content_item/content_item.dart
@@ -76,7 +76,7 @@ class ContentItem extends StatefulWidget {
   final String contentTypeName;
   final Uri? openLinkUri;
   final int? numComments;
-  final Future<void> Function(String)? onReply;
+  final Future<void> Function(String body, String lang)? onReply;
   final Future<void> Function(String)? onReport;
   final Future<void> Function(String)? onEdit;
   final Future<void> Function()? onDelete;
@@ -178,7 +178,15 @@ class ContentItem extends StatefulWidget {
 
 class _ContentItemState extends State<ContentItem> {
   TextEditingController? _replyTextController;
+  late String _replyLanguage;
   TextEditingController? _editTextController;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _replyLanguage = context.read<AppController>().profile.defaultPostLanguage;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -819,6 +827,29 @@ class _ContentItemState extends State<ContentItem> {
                                   Row(
                                     mainAxisAlignment: MainAxisAlignment.end,
                                     children: [
+                                      IconButton(
+                                        onPressed: () async {
+                                          final newLang =
+                                              await languageSelectionMenu(
+                                                context,
+                                              ).askSelection(
+                                                context,
+                                                _replyLanguage,
+                                              );
+
+                                          if (newLang != null) {
+                                            setState(() {
+                                              _replyLanguage = newLang;
+                                            });
+                                          }
+                                        },
+                                        icon: Icon(Symbols.globe_rounded),
+                                        tooltip: getLanguageName(
+                                          context,
+                                          _replyLanguage,
+                                        ),
+                                      ),
+                                      const SizedBox(width: 8),
                                       OutlinedButton(
                                         onPressed: () => setState(() {
                                           _replyTextController!.dispose();
@@ -831,6 +862,7 @@ class _ContentItemState extends State<ContentItem> {
                                         onPressed: () async {
                                           await widget.onReply!(
                                             _replyTextController!.text,
+                                            _replyLanguage,
                                           );
 
                                           await replyDraftController.discard();
@@ -1156,6 +1188,25 @@ class _ContentItemState extends State<ContentItem> {
                           Row(
                             mainAxisAlignment: MainAxisAlignment.end,
                             children: [
+                              IconButton(
+                                onPressed: () async {
+                                  final newLang = await languageSelectionMenu(
+                                    context,
+                                  ).askSelection(context, _replyLanguage);
+
+                                  if (newLang != null) {
+                                    setState(() {
+                                      _replyLanguage = newLang;
+                                    });
+                                  }
+                                },
+                                icon: Icon(Symbols.globe_rounded),
+                                tooltip: getLanguageName(
+                                  context,
+                                  _replyLanguage,
+                                ),
+                              ),
+                              const SizedBox(width: 8),
                               OutlinedButton(
                                 onPressed: () => setState(() {
                                   _replyTextController!.dispose();
@@ -1168,6 +1219,7 @@ class _ContentItemState extends State<ContentItem> {
                                 onPressed: () async {
                                   await widget.onReply!(
                                     _replyTextController!.text,
+                                    _replyLanguage,
                                   );
 
                                   await replyDraftController.discard();

--- a/lib/src/widgets/content_item/content_menu.dart
+++ b/lib/src/widgets/content_item/content_menu.dart
@@ -324,7 +324,7 @@ void showContentMenu(
                     LoadingListTile(
                       title: Text('Translate'),
                       onTap: () async {
-                        await onTranslate(ac.profile.defaultPostLanguage);
+                        await onTranslate(ac.profile.defaultCreateLanguage);
                         if (!context.mounted) return;
                         Navigator.pop(context);
                       },
@@ -333,7 +333,7 @@ void showContentMenu(
                           final langCode = await languageSelectionMenu(context)
                               .askSelection(
                                 context,
-                                ac.selectedProfileValue.defaultPostLanguage,
+                                ac.selectedProfileValue.defaultCreateLanguage,
                               );
 
                           if (langCode == null) return;


### PR DESCRIPTION
- Posts and comments now have the associated language attached under Lemmy and PieFed (already existed for Mbin). Unfortunately, this required passing around a list of language codes with language IDs, but I'm not really sure there's a better way to do it.
- Creating a post will correctly set the given language for Lemmy and PieFed (already existed for Mbin).
- Posts and comments now display a little badge with the associated language code, and a tooltip for the full name.
- Add language selection on comment creation.
- Change the defaultPostLang setting to defaultCreateLang (to accommodate being used with both posts and comments).
-  Language badge will only display if it's different from defaultCreateLanguage.

