### PR TITLE
Add secondary actions to the navigation bar.

### DIFF
--- a/lib/src/app_home.dart
+++ b/lib/src/app_home.dart
@@ -4,6 +4,7 @@ import 'package:interstellar/src/screens/account/account_screen.dart';
 import 'package:interstellar/src/screens/account/notification/notification_badge.dart';
 import 'package:interstellar/src/screens/explore/explore_screen.dart';
 import 'package:interstellar/src/screens/feed/feed_screen.dart';
+import 'package:interstellar/src/screens/settings/account_selection.dart';
 import 'package:interstellar/src/screens/settings/settings_screen.dart';
 import 'package:interstellar/src/utils/breakpoints.dart';
 import 'package:interstellar/src/utils/utils.dart';
@@ -24,8 +25,35 @@ class _AppHomeState extends State<AppHome> {
   Key _feedKey = UniqueKey();
   Key _exploreKey = UniqueKey();
   Key _accountKey = UniqueKey();
+  final ScrollController _feedScrollController = ScrollController();
+  final FocusNode _exploreFocusNode = FocusNode();
 
   void _changeNav(int newIndex) {
+    if (newIndex == _navIndex) {
+      switch (newIndex) {
+        case 0:
+          _feedScrollController.animateTo(
+            _feedScrollController.position.minScrollExtent,
+            duration: Durations.long1,
+            curve: Curves.easeInOut,
+          );
+          return;
+        case 1:
+          _exploreFocusNode.requestFocus();
+          return;
+        case 2:
+          () async {
+            final ac = context.read<AppController>();
+            final newAccount = await switchAccount(context);
+            if (newAccount == null || newAccount == ac.selectedAccount) {
+              return;
+            }
+
+            await ac.switchAccounts(newAccount);
+          } ();
+          return;
+      }
+    }
     setState(() {
       _navIndex = newIndex;
     });
@@ -129,8 +157,8 @@ class _AppHomeState extends State<AppHome> {
               controller: _pageController,
               physics: const NeverScrollableScrollPhysics(),
               children: [
-                FeedScreen(key: _feedKey),
-                ExploreScreen(key: _exploreKey),
+                FeedScreen(key: _feedKey, scrollController: _feedScrollController),
+                ExploreScreen(key: _exploreKey, focusNode: _exploreFocusNode),
                 AccountScreen(key: _accountKey),
                 SettingsScreen(),
               ],

--- a/lib/src/app_home.dart
+++ b/lib/src/app_home.dart
@@ -5,6 +5,7 @@ import 'package:interstellar/src/screens/account/notification/notification_badge
 import 'package:interstellar/src/screens/explore/explore_screen.dart';
 import 'package:interstellar/src/screens/feed/feed_screen.dart';
 import 'package:interstellar/src/screens/settings/account_selection.dart';
+import 'package:interstellar/src/screens/settings/profile_selection.dart';
 import 'package:interstellar/src/screens/settings/settings_screen.dart';
 import 'package:interstellar/src/utils/breakpoints.dart';
 import 'package:interstellar/src/utils/utils.dart';
@@ -51,6 +52,9 @@ class _AppHomeState extends State<AppHome> {
 
             await ac.switchAccounts(newAccount);
           } ();
+          return;
+        case 3:
+          switchProfileSelect(context);
           return;
       }
     }

--- a/lib/src/screens/explore/explore_screen.dart
+++ b/lib/src/screens/explore/explore_screen.dart
@@ -13,8 +13,9 @@ import 'package:provider/provider.dart';
 
 class ExploreScreen extends StatefulWidget {
   final ExploreType? subOnlyMode;
+  final FocusNode? focusNode;
 
-  const ExploreScreen({this.subOnlyMode, super.key});
+  const ExploreScreen({this.subOnlyMode, this.focusNode, super.key});
 
   @override
   State<ExploreScreen> createState() => _ExploreScreenState();
@@ -200,8 +201,9 @@ class _ExploreScreenState extends State<ExploreScreen>
                           filled: true,
                           hintText: l(context).searchTheFediverse,
                         ),
+                        focusNode: widget.focusNode,
                         onTapOutside: (event) {
-                          FocusManager.instance.primaryFocus?.unfocus();
+                          widget.focusNode?.unfocus();
                         },
                       ),
                       const SizedBox(height: 12),

--- a/lib/src/screens/feed/feed_screen.dart
+++ b/lib/src/screens/feed/feed_screen.dart
@@ -30,6 +30,7 @@ class FeedScreen extends StatefulWidget {
   final String? title;
   final Widget? details;
   final DetailedCommunityModel? createPostCommunity;
+  final ScrollController? scrollController;
 
   const FeedScreen({
     super.key,
@@ -38,6 +39,7 @@ class FeedScreen extends StatefulWidget {
     this.title,
     this.details,
     this.createPostCommunity,
+    this.scrollController,
   });
 
   @override
@@ -320,6 +322,7 @@ class _FeedScreenState extends State<FeedScreen>
           },
           child: SafeArea(
             child: NestedScrollView(
+              controller: widget.scrollController,
               floatHeaderSlivers: true,
               headerSliverBuilder: (context, isScrolled) {
                 final ac = context.read<AppController>();


### PR DESCRIPTION
When tapping feed navigation destination while the feed is open it scrolls to the top.
Tapping explore while explore page is open will move focus to the search bar.
Tapping account while account page is open will open the account switcher.
Closes #215 