### PR TITLE
Grey out settings irrelevant to current account

### DIFF
--- a/lib/src/screens/settings/behavior_screen.dart
+++ b/lib/src/screens/settings/behavior_screen.dart
@@ -49,13 +49,12 @@ class BehaviorSettingsScreen extends StatelessWidget {
             title: Text(l(context).settings_useAccountLanguageFilter),
             subtitle: Text(l(context).settings_useAccountLanguageFilter_help),
             value: ac.profile.useAccountLanguageFilter,
-            onChanged: ac.serverSoftware != ServerSoftware.mbin
-                ? null
-                : (newValue) => ac.updateProfile(
+            onChanged: (newValue) => ac.updateProfile(
                     ac.selectedProfileValue.copyWith(
                       useAccountLanguageFilter: newValue,
                     ),
                   ),
+            enabled: ac.serverSoftware == ServerSoftware.mbin,
           ),
           Row(
             children: [
@@ -200,6 +199,7 @@ class BehaviorSettingsScreen extends StatelessWidget {
                 markMicroblogsReadOnScroll: newValue,
               ),
             ),
+            enabled: ac.serverSoftware == ServerSoftware.mbin,
           ),
           ListTile(
             title: Column(

--- a/lib/src/screens/settings/display_screen.dart
+++ b/lib/src/screens/settings/display_screen.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
 import 'package:interstellar/src/controller/controller.dart';
+import 'package:interstellar/src/controller/server.dart';
 import 'package:interstellar/src/utils/language.dart';
 import 'package:interstellar/src/utils/utils.dart';
 import 'package:interstellar/src/widgets/list_tile_switch.dart';
@@ -179,6 +180,7 @@ class DisplaySettingsScreen extends StatelessWidget {
                       fullImageSizeMicroblogs: newValue,
                     ),
                   ),
+            enabled: ac.serverSoftware == ServerSoftware.mbin,
           ),
         ],
       ),

--- a/lib/src/screens/settings/feed_defaults_screen.dart
+++ b/lib/src/screens/settings/feed_defaults_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:interstellar/src/api/comments.dart';
 import 'package:interstellar/src/controller/controller.dart';
+import 'package:interstellar/src/controller/server.dart';
 import 'package:interstellar/src/screens/feed/feed_screen.dart';
 import 'package:interstellar/src/utils/utils.dart';
 import 'package:interstellar/src/widgets/list_tile_select.dart';
@@ -29,6 +30,7 @@ class FeedDefaultSettingsScreen extends StatelessWidget {
             onChange: (newValue) => ac.updateProfile(
               ac.selectedProfileValue.copyWith(feedDefaultView: newValue),
             ),
+            enabled: ac.serverSoftware == ServerSoftware.mbin,
           ),
           ListTileSelect(
             title: l(context).settings_feedDefaults_filter,

--- a/lib/src/widgets/list_tile_select.dart
+++ b/lib/src/widgets/list_tile_select.dart
@@ -9,6 +9,7 @@ class ListTileSelect<T> extends StatelessWidget {
   final T value;
   final T? oldValue;
   final void Function(T newValue) onChange;
+  final bool enabled;
 
   const ListTileSelect({
     super.key,
@@ -18,6 +19,7 @@ class ListTileSelect<T> extends StatelessWidget {
     required this.value,
     required this.oldValue,
     required this.onChange,
+    this.enabled = true,
   });
 
   @override
@@ -43,6 +45,7 @@ class ListTileSelect<T> extends StatelessWidget {
 
         onChange(newValue);
       },
+      enabled: enabled,
     );
   }
 }

--- a/lib/src/widgets/list_tile_switch.dart
+++ b/lib/src/widgets/list_tile_switch.dart
@@ -6,6 +6,7 @@ class ListTileSwitch extends StatelessWidget {
   final Widget? leading;
   final Widget? title;
   final Widget? subtitle;
+  final bool enabled;
 
   const ListTileSwitch({
     required this.value,
@@ -13,21 +14,19 @@ class ListTileSwitch extends StatelessWidget {
     this.leading,
     this.title,
     this.subtitle,
+    this.enabled = true,
     super.key,
   });
 
   @override
   Widget build(BuildContext context) {
-    final color = onChanged == null ? Theme.of(context).disabledColor : null;
-
     return ListTile(
       leading: leading,
       title: title,
       subtitle: subtitle,
       onTap: onChanged == null ? null : () => onChanged!(!value),
-      trailing: Switch(value: value, onChanged: onChanged),
-      textColor: color,
-      iconColor: color,
+      trailing: Switch(value: value, onChanged: enabled ? onChanged : null),
+      enabled: enabled,
     );
   }
 }


### PR DESCRIPTION
Grey out settings which are only relevant for mbin when logged in on a non mbin account.

Greys out 
- mark microblogs read on scroll
- full image size for microblogs
- view default

- use account language filter
- notifications
are already greyed out.
