### PR TITLE
Login autofill fix

### DIFF
--- a/lib/src/screens/settings/login_confirm.dart
+++ b/lib/src/screens/settings/login_confirm.dart
@@ -57,34 +57,36 @@ class _LoginConfirmScreenState extends State<LoginConfirmScreen> {
               widget.software == ServerSoftware.piefed)
             Padding(
               padding: const EdgeInsets.all(16),
-              child: Column(
-                children: [
-                  TextEditor(
-                    _usernameEmailTextController,
-                    label: l(context).usernameOrEmail,
-                    keyboardType: TextInputType.emailAddress,
-                    onChanged: (_) => setState(() {}),
-                    autofillHints: [
-                      AutofillHints.username,
-                      AutofillHints.email,
-                    ],
-                  ),
-                  const SizedBox(height: 12),
-                  PasswordEditor(
-                    _passwordTextController,
-                    onChanged: (_) => setState(() {}),
-                  ),
-                  if (widget.software == ServerSoftware.lemmy) ...[
-                    const SizedBox(height: 12),
+              child: AutofillGroup(
+                child: Column(
+                  children: [
                     TextEditor(
-                      _totpTokenTextController,
-                      label: l(context).totpToken,
-                      keyboardType: TextInputType.number,
-                      maxLength: 6,
+                      _usernameEmailTextController,
+                      label: l(context).usernameOrEmail,
+                      keyboardType: TextInputType.emailAddress,
+                      onChanged: (_) => setState(() {}),
+                      autofillHints: [
+                        AutofillHints.username,
+                        AutofillHints.email,
+                      ],
                     ),
+                    const SizedBox(height: 12),
+                    PasswordEditor(
+                      _passwordTextController,
+                      onChanged: (_) => setState(() {}),
+                    ),
+                    if (widget.software == ServerSoftware.lemmy) ...[
+                      const SizedBox(height: 12),
+                      TextEditor(
+                        _totpTokenTextController,
+                        label: l(context).totpToken,
+                        keyboardType: TextInputType.number,
+                        maxLength: 6,
+                      ),
+                    ],
                   ],
-                ],
-              ),
+                ),
+              )
             ),
           Row(
             mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/src/screens/settings/login_select.dart
+++ b/lib/src/screens/settings/login_select.dart
@@ -136,6 +136,7 @@ class _LoginSelectScreenState extends State<LoginSelectScreen> {
           TextEditor(
             _instanceHostController,
             label: l(context).instanceHost,
+            keyboardType: TextInputType.url,
             onChanged: (_) => setState(() {}),
           ),
           const SizedBox(height: 12),


### PR DESCRIPTION
- Wrap lemmy/piefed login inputs in autofill group. 
  Previously autofill only worked one input at a time. This should autofill username/password at same time.
- Add input type for instance url input. 
  Should help with users who have autocorrect turned on. Should prevent things like automatically adding space after a period or auto capitalization.