### PR TITLE
Couple of tweaks to cross post ui

### DIFF
--- a/lib/src/screens/feed/post_page.dart
+++ b/lib/src/screens/feed/post_page.dart
@@ -228,6 +228,7 @@ class _PostPageState extends State<PostPage> {
                             .map(
                               (crossPost) => ContextMenuItem(
                                 title: crossPost.community.name,
+                                subtitle: l(context).commentsX(crossPost.numComments),
                                 onTap: () => pushRoute(
                                   context,
                                   builder: (context) => PostPage(
@@ -257,36 +258,39 @@ class _PostPageState extends State<PostPage> {
                 key: _mainCommentSectionKey,
               ),
               if (context.read<AppController>().profile.showCrosspostComments)
-                ...post.crossPosts.map(
-                  (crossPost) => SliverMainAxisGroup(
-                    slivers: [
-                      SliverToBoxAdapter(
-                        child: ListTile(
-                          title: Text(
-                            l(
-                              context,
-                            ).crossPostComments(crossPost.community.name),
-                            style: Theme.of(context).textTheme.titleLarge,
-                          ),
-                          onTap: () => pushRoute(
-                            context,
-                            builder: (context) => PostPage(
-                              postType: crossPost.type,
-                              postId: crossPost.id,
-                              initData: crossPost,
+                ...post.crossPosts
+                    .where((crossPost) => crossPost.numComments > 0)
+                    .map(
+                      (crossPost) => SliverMainAxisGroup(
+                        slivers: [
+                          SliverToBoxAdapter(child: const Divider()),
+                          SliverToBoxAdapter(
+                            child: ListTile(
+                              title: Text(
+                                l(
+                                  context,
+                                ).crossPostComments(crossPost.community.name),
+                                style: Theme.of(context).textTheme.titleMedium,
+                              ),
+                              onTap: () => pushRoute(
+                                context,
+                                builder: (context) => PostPage(
+                                  postType: crossPost.type,
+                                  postId: crossPost.id,
+                                  initData: crossPost,
+                                ),
+                              ),
                             ),
                           ),
-                        ),
+                          CommentSection(
+                            id: crossPost.id,
+                            postType: crossPost.type,
+                            sort: commentSort,
+                            opUserId: crossPost.user.id,
+                          ),
+                        ],
                       ),
-                      CommentSection(
-                        id: crossPost.id,
-                        postType: crossPost.type,
-                        sort: commentSort,
-                        opUserId: crossPost.user.id,
-                      ),
-                    ],
-                  ),
-                ),
+                    ),
             ],
           ),
         ),


### PR DESCRIPTION
- Change font size for cross post comment titles from titleLarge to titleMedium.
- Add divider between cross post comment sections.
- Add comment count as subtitle in menu under cross post button.
- Don't include empty comment sections in combined comment sections.

Closes #272 