### PR TITLE
Move account page nav location.

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -208,11 +208,13 @@
   "account_settings_notifyOnThreadCommentReply": "Notify on thread comment reply",
   "account_settings_notifyOnMicroblogReply": "Notify on comments in authored microblogs",
   "account_settings_notifyOnMicroblogCommentReply": "Notify on microblog comment reply",
+  "inbox": "Inbox",
   "notifications": "Notifications",
   "notifications_readAll": "Mark all as read",
   "notifications_registerPush": "Register for push notifications",
   "notifications_unregisterPush": "Unregister push notifications",
   "messages": "Messages",
+  "newChat": "New chat",
   "reply": "Reply",
   "replying_toX": "Replying to {user}",
   "@replying_toX": {

--- a/lib/src/app_home.dart
+++ b/lib/src/app_home.dart
@@ -2,8 +2,10 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:interstellar/src/controller/controller.dart';
-import 'package:interstellar/src/screens/account/account_screen.dart';
+import 'package:interstellar/src/screens/account/inbox_screen.dart';
+import 'package:interstellar/src/screens/account/messages/message_thread_screen.dart';
 import 'package:interstellar/src/screens/account/notification/notification_badge.dart';
+import 'package:interstellar/src/screens/account/self_feed.dart';
 import 'package:interstellar/src/screens/explore/explore_screen.dart';
 import 'package:interstellar/src/screens/feed/feed_screen.dart';
 import 'package:interstellar/src/screens/settings/account_selection.dart';
@@ -29,6 +31,7 @@ class _AppHomeState extends State<AppHome> {
   Key _feedKey = UniqueKey();
   Key _exploreKey = UniqueKey();
   Key _accountKey = UniqueKey();
+  Key _inboxKey = UniqueKey();
   final ScrollController _feedScrollController = ScrollController();
   final FocusNode _exploreFocusNode = FocusNode();
   int _exitCounter = 0;
@@ -58,6 +61,22 @@ class _AppHomeState extends State<AppHome> {
           }();
           return;
         case 3:
+          pushRoute(
+            context,
+            builder: (context) => ExploreScreen(
+              mode: ExploreType.people,
+              title: l(context).newChat,
+              onTap: (selected, item) async {
+                Navigator.pop(context);
+                await pushRoute(
+                  context,
+                  builder: (context) =>
+                      MessageThreadScreen(threadId: null, otherUser: item),
+                );
+              },
+            ),
+          );
+        case 4:
           switchProfileSelect(context);
           return;
       }
@@ -97,6 +116,7 @@ class _AppHomeState extends State<AppHome> {
         _feedKey = UniqueKey();
         _exploreKey = UniqueKey();
         _accountKey = UniqueKey();
+        _inboxKey = UniqueKey();
       });
     };
 
@@ -134,6 +154,11 @@ class _AppHomeState extends State<AppHome> {
                       parentBuilder: (child) => NotificationBadge(child: child),
                       child: const Icon(Symbols.person_rounded, fill: 1),
                     ),
+                  ),
+                  NavigationDestination(
+                    label: l(context).inbox,
+                    icon: const Icon(Symbols.inbox_rounded),
+                    selectedIcon: const Icon(Symbols.inbox_rounded, fill: 1),
                   ),
                   NavigationDestination(
                     label: l(context).settings,
@@ -176,6 +201,11 @@ class _AppHomeState extends State<AppHome> {
                     ),
                   ),
                   NavigationRailDestination(
+                    label: Text(l(context).inbox),
+                    icon: const Icon(Symbols.inbox_rounded),
+                    selectedIcon: const Icon(Symbols.inbox_rounded, fill: 1),
+                  ),
+                  NavigationRailDestination(
                     label: Text(l(context).settings),
                     icon: const Icon(Symbols.settings_rounded),
                     selectedIcon: const Icon(Symbols.settings_rounded, fill: 1),
@@ -193,7 +223,8 @@ class _AppHomeState extends State<AppHome> {
                     scrollController: _feedScrollController,
                   ),
                   ExploreScreen(key: _exploreKey, focusNode: _exploreFocusNode),
-                  AccountScreen(key: _accountKey),
+                  SelfFeed(key: _accountKey),
+                  InboxScreen(key: _inboxKey),
                   SettingsScreen(),
                 ],
               ),

--- a/lib/src/screens/account/inbox_screen.dart
+++ b/lib/src/screens/account/inbox_screen.dart
@@ -2,22 +2,21 @@ import 'package:flutter/material.dart';
 import 'package:interstellar/src/controller/controller.dart';
 import 'package:interstellar/src/screens/account/notification/notification_badge.dart';
 import 'package:interstellar/src/screens/account/notification/notification_screen.dart';
-import 'package:interstellar/src/screens/account/self_feed.dart';
 import 'package:interstellar/src/utils/utils.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:provider/provider.dart';
 
 import 'messages/messages_screen.dart';
 
-class AccountScreen extends StatefulWidget {
-  const AccountScreen({super.key});
+class InboxScreen extends StatefulWidget {
+  const InboxScreen({super.key});
 
   @override
-  State<AccountScreen> createState() => _AccountScreenState();
+  State<InboxScreen> createState() => _InboxScreenState();
 }
 
-class _AccountScreenState extends State<AccountScreen>
-    with AutomaticKeepAliveClientMixin<AccountScreen> {
+class _InboxScreenState extends State<InboxScreen>
+    with AutomaticKeepAliveClientMixin<InboxScreen> {
   @override
   bool get wantKeepAlive => true;
 
@@ -27,7 +26,7 @@ class _AccountScreenState extends State<AccountScreen>
     return whenLoggedIn(
           context,
           DefaultTabController(
-            length: 3,
+            length: 2,
             child: Scaffold(
               appBar: AppBar(
                 title: Text(context.watch<AppController>().selectedAccount),
@@ -43,10 +42,6 @@ class _AccountScreenState extends State<AccountScreen>
                       text: l(context).messages,
                       icon: const Icon(Symbols.message_rounded),
                     ),
-                    Tab(
-                      text: l(context).account_overview,
-                      icon: const Icon(Symbols.person_rounded),
-                    ),
                   ],
                 ),
               ),
@@ -55,7 +50,6 @@ class _AccountScreenState extends State<AccountScreen>
                 children: const [
                   NotificationsScreen(),
                   MessagesScreen(),
-                  SelfFeed(),
                 ],
               ),
             ),

--- a/lib/src/screens/account/messages/messages_screen.dart
+++ b/lib/src/screens/account/messages/messages_screen.dart
@@ -82,7 +82,7 @@ class _MessagesScreenState extends State<MessagesScreen>
                 context,
                 builder: (context) => ExploreScreen(
                   mode: ExploreType.people,
-                  title: 'New chat',
+                  title: l(context).newChat,
                   onTap: (selected, item) async {
                     Navigator.of(context).pop();
                     await pushRoute(


### PR DESCRIPTION
- Move account page to navigation bar.
- Rename current account nav to inbox.
- Double tap inbox to create new message.

Closes #260 