### PR TITLE
Fix direct message page error for piefed.

### DIFF
--- a/lib/src/screens/account/messages/message_thread_screen.dart
+++ b/lib/src/screens/account/messages/message_thread_screen.dart
@@ -95,10 +95,12 @@ class _MessageThreadScreenState extends State<MessageThreadScreen> {
     final myUsername = context.watch<AppController>().localName;
 
     final messageUser =
-        _data?.participants.firstWhere(
-          (user) => user.name != myUsername,
-          orElse: () => _data!.participants.first,
-        ) ??
+        (_data != null && _data!.participants.isNotEmpty
+            ? _data?.participants.firstWhere(
+                (user) => user.name != myUsername,
+                orElse: () => _data!.participants.first,
+              )
+            : null) ??
         widget.otherUser;
 
     final messageDraftController = context.watch<DraftsController>().auto(


### PR DESCRIPTION
Looks like this error was due to no messages with the user in the first returned page of messages which resulted in an empty participant list.

Closes #287 